### PR TITLE
Add file copyright and license headers

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_0_TOC.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_0_TOC.adoc
@@ -1,12 +1,15 @@
-image:extracted-media/media/image3.png[image,width=390,height=180]image:extracted-media/media/image2.png[image,width=44,height=25]image:extracted-media/media/image4.png[image,width=400,height=160]
-_Version 3.0_
-
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
+
+image:extracted-media/media/image3.png[image,width=390,height=180]image:extracted-media/media/image2.png[image,width=44,height=25]image:extracted-media/media/image4.png[image,width=400,height=160]
+_Version 3.0_
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_10_Appendix.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_10_Appendix.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Message_Flow.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Message_Flow.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_9_Acknowledgements.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_9_Acknowledgements.adoc
@@ -1,9 +1,12 @@
-Copyright © 2016-2020 Eclipse Foundation, Inc, Cirrus Link Solutions, and others
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0.
+
 SPDX-License-Identifier: EPL-2.0
+////
 
 _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation_
 

--- a/specification/src/main/asciidoc/sparkplug_spec.adoc
+++ b/specification/src/main/asciidoc/sparkplug_spec.adoc
@@ -1,3 +1,13 @@
+////
+Copyright © 2016-2020 The Eclipse Foundation, Cirrus Link Solutions, and others
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0.
+
+SPDX-License-Identifier: EPL-2.0
+////
+
 = Sparkplug 1.0.0-SNAPSHOT: Sparkplug Specification
 Eclipse Sparkplug Contributors
 Version 1.0.0-SNAPSHOT Snapshot Release, November 2020


### PR DESCRIPTION
This commit adds file headers to the source files.

Note that license expressed in the file headers is for the source itself. I've changed some of the text that I found in the files, added as fine content. What you have isn't quite right. 

The Eclipse Foundation is not a copyright holder of the source, the actual authors (or, more likely, their employer) are the copyright holders. I believe that expressing this as "Cirrus Link Solutions, and others" is correct. When we release the specification itself (as a "Final Specification"), the released version that is generated from this source will be distributed Copyright of the EF and distributed under the EFSL. I'm keeping that part separate (I'll help separately with that).