### PR TITLE
Remove excessive copies of TM symbol #24

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -16,13 +16,13 @@ _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation
 [[introduction_rationale_and_use_case]]
 === Rationale and Use Case
 
-Sparkplug™ provides an open and freely available specification for how Edge of Network (EoN) gateways or 
+Eclipse Sparkplug™ provides an open and freely available specification for how Edge of Network (EoN) gateways or 
 native MQTT enabled end devices and MQTT Applications communicate bi-directionally within an MQTT 
-Infrastructure. This document details the structure and implementation requirements for Sparkplug™ compliant 
+Infrastructure. This document details the structure and implementation requirements for Sparkplug compliant 
 MQTT Client implementations on both devices and applications.
 
 It is recognized that MQTT is used across a wide spectrum of application solution use cases, and an almost 
-indefinable variation of network topologies. To that end the Sparkplug™ specification strives to accomplish 
+indefinable variation of network topologies. To that end the Sparkplug specification strives to accomplish 
 the three following goals.
 
 [[introduction_define_an_mqtt_topic_namespace]]
@@ -30,7 +30,7 @@ the three following goals.
 
 As noted many times in this document one of the many attractive features of MQTT is that is does not specify 
 any required Topic Namespace within its implementation. This fact has meant that MQTT has taken a dominant 
-position across a wide spectrum of IoT solutions. The intent of the Sparkplug™ specification is to identify 
+position across a wide spectrum of IoT solutions. The intent of the Sparkplug pecification is to identify 
 and document a Topic Namespace that is well thought out and optimized for the SCADA/IIoT solution sector.
 
 [[introduction_define_mqtt_state_management]]
@@ -39,21 +39,21 @@ and document a Topic Namespace that is well thought out and optimized for the SC
 One of the unique aspects of MQTT is that it was originally designed for real time SCADA systems to help 
 reduce data latency over bandwidth limited and often unreliable network infrastructure. In many 
 implementations though the full benefit of this “Continuous Session Awareness” is not well understood, or not 
-even implemented. The intent of the Sparkplug™ specification is to take full advantage of MQTT’s native 
+even implemented. The intent of the Sparkplug specification is to take full advantage of MQTT’s native 
 Continuous Session Awareness capability as it applies to real time SCADA/IIoT solutions.
 
 [[introduction_define_the_mqtt_payload]]
 ==== Define the MQTT Payload
 
 Just as the MQTT specification does not dictate any particular Topic Namespace, nor does it dictate any 
-particular payload data encoding. The intent of the Sparkplug™ specification is to strive to define payload 
+particular payload data encoding. The intent of the Sparkplug specification is to strive to define payload 
 encoding architectures that remain true to the original, lightweight, bandwidth efficient, low latency 
 features of MQTT while adding modern encoding schemes targeting the SCADA/IIoT solution space.
 
-Sparkplug™ has defined an approach where the Topic Namespace can aid in the determination of the encoding 
-scheme of any particular payload. Currently there are two (2) Sparkplug™ defined encoding schemes that this 
-specification supports. The first one is the Sparkplug™ A encoding scheme based on the very popular Kura open 
-source Google Protocol Buffer definition. The second one is the Sparkplug™ B encoding scheme that provides a 
+Sparkplug has defined an approach where the Topic Namespace can aid in the determination of the encoding 
+scheme of any particular payload. Currently there are two (2) Sparkplug defined encoding schemes that this 
+specification supports. The first one is the Sparkplug A encoding scheme based on the very popular Kura open 
+source Google Protocol Buffer definition. The second one is the Sparkplug B encoding scheme that provides a 
 richer data model developed with the feedback of many system integrators and end user customers using MQTT.
 
 [[introduction_background]]
@@ -69,14 +69,14 @@ infrastructure is not defined. All of this was intentional within the original s
 maximum flexibility across any solution sector that might choose to use MQTT infrastructures.
 
 But at some point, for MQTT based solutions to be interoperable within a given market sector, the Topic 
-Namespace, Payload representation and session state must be defined. The intent and purpose of the Sparkplug™ 
+Namespace, Payload representation and session state must be defined. The intent and purpose of the Sparkplug 
 specification is to define an MQTT Topic Namespace, payload, and session state management that can be applied 
 generically to the overall IIoT market sector, but specifically meets the requirements of real-time 
 SCADA/Control HMI solutions. Meeting the operational requirements for these systems will enable MQTT based 
 infrastructures to provide more valuable real-time information to Line of Business and MES solution 
 requirements as well.
 
-The purpose of the Sparkplug™ specification is to remain true to the original notion of keeping the Topic 
+The purpose of the Sparkplug specification is to remain true to the original notion of keeping the Topic 
 Namespace and message sizes to a minimum while still making the overall message transactions and session 
 state management between MQTT devices and MQTT SCADA/IIoT applications simple, efficient and easy to 
 understand and implement.
@@ -152,7 +152,7 @@ Figure 1 - MQTT SCADA Infrastructure
 ===== MQTT Server(s)
 
 MQTT enabled infrastructure requires that one or more MQTT Servers are present in the infrastructure. The 
-only requirement that the Sparkplug™ specification places on the selection of an MQTT Server component in the 
+only requirement that the Sparkplug specification places on the selection of an MQTT Server component in the 
 architecture is it is required to be compliant with the latest MQTT V3.1.1 specification and is sized to 
 properly manage all MQTT message traffic.
 
@@ -175,11 +175,11 @@ The Device/Sensor represents any physical or logical device connected to the MQT
 data, process variables or metrics.
 
 [[introduction_mqtt_enabled_device]]
-===== MQTT Enabled Device(Sparkplug™)
+===== MQTT Enabled Device(Sparkplug)
 
 This represents any device, sensor, or hardware that directly connects to MQTT infrastructure using a 
-compliant MQTT 3.1.1 connection with the payload and topic notation as outlined in this Sparkplug™ 
-specification. Note that it will be represented as an EoN node in the Sparkplug™ topic payload.
+compliant MQTT 3.1.1 connection with the payload and topic notation as outlined in this Sparkplug 
+specification. Note that it will be represented as an EoN node in the Sparkplug topic payload.
 
 [[introduction_scada_iiot_host]]
 ===== SCADA/IIoT Host
@@ -187,7 +187,7 @@ specification. Note that it will be represented as an EoN node in the Sparkplug�
 The SCADA/IIoT Host Node is any MQTT Client application that subscribes to and publishes messages defined in 
 this document. In typical SCADA/IIoT infrastructure implementations, there will be only one *Primary* 
 SCADA/IIoT Host Node responsible for the monitoring and control of a given group of MQTT EoN nodes. 
-Sparkplug™ does support the notion of multiple critical Host applications. This does not preclude any number 
+Sparkplug does support the notion of multiple critical Host applications. This does not preclude any number 
 of additional MQTT SCADA/IIoT Nodes participating in the infrastructure that are in either a pure monitoring 
 mode, or in the role of a hot standby should the Primary MQTT SCADA/IIoT Host go offline.
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
@@ -46,11 +46,11 @@ The Device/Sensor represents any physical or logical device connected to the MQT
 data, process variables or metrics.
 
 [[components_mqtt_enabled_device]]
-=== MQTT Enabled Device (Sparkplug™)
+=== MQTT Enabled Device (Sparkplug)
 
 This represents any device, sensor, or hardware that directly connects to MQTT infrastructure using a 
-compliant MQTT 3.1.1 connection with the payload and topic notation as outlined in this Sparkplug™ 
-specification. Note that it will be represented as an EoN node in the Sparkplug™ topic payload.
+compliant MQTT 3.1.1 connection with the payload and topic notation as outlined in this Sparkplug 
+specification. Note that it will be represented as an EoN node in the Sparkplug topic payload.
 
 [[components_scada_iiot_host]]
 === SCADA / IIoT Host
@@ -58,7 +58,7 @@ specification. Note that it will be represented as an EoN node in the Sparkplug�
 The SCADA/IIoT Host Node is any MQTT Client application that subscribes to and publishes messages defined in 
 this document. In typical SCADA/IIoT infrastructure implementations, there will be only one *Primary* 
 SCADA/IIoT Host Node responsible for the monitoring and control of a given group of MQTT EoN nodes. 
-Sparkplug™ does support the notion of multiple critical Host applications. This does not preclude any number 
+Sparkplug does support the notion of multiple critical Host applications. This does not preclude any number 
 of additional MQTT SCADA/IIoT Nodes participating in the infrastructure that are in either a pure monitoring 
 mode, or in the role of a hot standby should the Primary MQTT SCADA/IIoT Host go offline.
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -15,29 +15,29 @@ _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation
 
 To get a working Message Oriented Middleware (MOM) based SCADA system using MQTT, the first thing that must be defined is a Topic Namespace to work within. The beauty of MQTT is the fact that you can just come up with an arbitrary topic like “Portland/Temperature”, connect to an MQTT Server, and start publishing the temperature value. For this data to be useful to other MQTT Client applications that want to consume the temperature values, the Topic Namespace needs to be understood by everyone participating in the data exchange.
 
-Every MQTT message published consist of a *_topic_* and a *_payload_* component. These components are the “overhead” of an MQTT message as measured in bytes on the wire. The Sparkplug™ specification is designed to keep these components meaningful and easy to understand, but not to get so verbose as to negatively impact bandwidth/time sensitive data exchange.
+Every MQTT message published consist of a *_topic_* and a *_payload_* component. These components are the “overhead” of an MQTT message as measured in bytes on the wire. The Sparkplug specification is designed to keep these components meaningful and easy to understand, but not to get so verbose as to negatively impact bandwidth/time sensitive data exchange.
 
 [[topics_sparkplug_topic_namesapce_elements]]
-=== Sparkplug™ Topic Namespace Elements
+=== Sparkplug Topic Namespace Elements
 
-All MQTT clients using the Sparkplug™ specification will use the following Topic Namespace structure:
+All MQTT clients using the Sparkplug specification will use the following Topic Namespace structure:
 
   namespace/group_id/message_type/edge_node_id/[device_id]
 
 [[topics_namespace_element]]
 ==== namespace Element
 
-The *_namespace_* element of the Topic Namespace is the root element that will define both the structure of the remaining namespace elements as well as the encoding used for the associated payload data. The current Sparkplug™ specification defines two (2) namespaces. One is for Sparkplug™ payload definition A, and another one of for the Sparkplug™ payload definition B.
+The *_namespace_* element of the Topic Namespace is the root element that will define both the structure of the remaining namespace elements as well as the encoding used for the associated payload data. The current Sparkplug specification defines two (2) namespaces. One is for Sparkplug payload definition A, and another one of for the Sparkplug payload definition B.
 
-For the Sparkplug™ A version of the payload definition, the UTF-8 string constant for the *namespace* element will be:
+For the Sparkplug A version of the payload definition, the UTF-8 string constant for the *namespace* element will be:
 
 *“spAv1.0”*
 
-For the Sparkplug™ B version of the specification, the UTF-8 string constant for the *_namespace_* element will be:
+For the Sparkplug B version of the specification, the UTF-8 string constant for the *_namespace_* element will be:
 
 *“spBv1.0”*
 
-Note that for the remainder of this document, the version of the Sparkplug™ Payload definition does not affect the Topic Namespace or session state management as they will remain the same. There are separate appendices that defines the encoding used for both the A and B versions of Sparkplug™ MQTT message payload.
+Note that for the remainder of this document, the version of the Sparkplug Payload definition does not affect the Topic Namespace or session state management as they will remain the same. There are separate appendices that defines the encoding used for both the A and B versions of Sparkplug MQTT message payload.
 
 [[topics_group_id_element]]
 ==== group_id Element
@@ -47,9 +47,9 @@ The *_group_id_* element of the Topic Namespace provides for a logical grouping 
 [[topics_message_type_element]]
 ==== message_type Element
 
-The *_message_type_* element of the Topic Namespace provides an indication as to how to handle the MQTT payload of the message. Note that the actual encoding of the payload will vary depending on the version of the Sparkplug™ implementation as indicated by the *_namespace_* element.
+The *_message_type_* element of the Topic Namespace provides an indication as to how to handle the MQTT payload of the message. Note that the actual encoding of the payload will vary depending on the version of the Sparkplug implementation as indicated by the *_namespace_* element.
 
-The following *_message_type_* elements are defined for the Sparkplug™ Topic Namespace:
+The following *_message_type_* elements are defined for the Sparkplug Topic Namespace:
 
 * *NBIRTH* – Birth certificate for MQTT EoN nodes.
 * *NDEATH* – Death certificate for MQTT EoN nodes.
@@ -66,20 +66,20 @@ The specification for each of these _message_type_ elements are detailed later i
 [[topics_edge_node_id_element]]
 ==== edge_node_id Element
 
-The *_edge_node_id_* element of the Sparkplug™ Topic Namespace uniquely identifies the MQTT EoN node within the infrastructure. The *_group_id_* combined with the *_edge_node_id_* element must be unique from any other *_group_id_*/*_edge_node_id_* assigned in the MQTT infrastructure. The format of the *_edge_node_id_* can be valid UTF-8 alphanumeric String with the exception of the reserved characters of ‘+’ (plus), ‘/’ (forward slash), and ‘#’ (number sign). The topic element *_edge_node_id_* travels with every message published and should be as short as possible.
+The *_edge_node_id_* element of the Sparkplug Topic Namespace uniquely identifies the MQTT EoN node within the infrastructure. The *_group_id_* combined with the *_edge_node_id_* element must be unique from any other *_group_id_*/*_edge_node_id_* assigned in the MQTT infrastructure. The format of the *_edge_node_id_* can be valid UTF-8 alphanumeric String with the exception of the reserved characters of ‘+’ (plus), ‘/’ (forward slash), and ‘#’ (number sign). The topic element *_edge_node_id_* travels with every message published and should be as short as possible.
 
 [[topics_device_id_element]]
 ==== device_id Element
 
-The *_device_id_* element of the Sparkplug™ Topic Namespace identifies a device attached (physically or logically) to the MQTT EoN node. Note that the *_device_id_* is an optional element within the Topic Namespace as some messages will be either originating or destined to the *_edge_node_id_* and the *_device_id_* would not be required. The format of the *_device_id_* is a valid UTF-8 alphanumeric String except for the reserved characters of ‘+’ (plus), ‘/’ (forward slash), and ‘#’ (number sign). The *_device_id_* must be unique from other devices connected to the same EoN node, but can be duplicated from EoN node to other EoN nodes. The device_id element travels with every message published and should be as short as possible.
+The *_device_id_* element of the Sparkplug Topic Namespace identifies a device attached (physically or logically) to the MQTT EoN node. Note that the *_device_id_* is an optional element within the Topic Namespace as some messages will be either originating or destined to the *_edge_node_id_* and the *_device_id_* would not be required. The format of the *_device_id_* is a valid UTF-8 alphanumeric String except for the reserved characters of ‘+’ (plus), ‘/’ (forward slash), and ‘#’ (number sign). The *_device_id_* must be unique from other devices connected to the same EoN node, but can be duplicated from EoN node to other EoN nodes. The device_id element travels with every message published and should be as short as possible.
 
 [[topics_sparkplug_mqtt_message_types]]
-=== Sparkplug™ MQTT Message Types
+=== Sparkplug MQTT Message Types
 
 [[topics_message_type_oeverview]]
 ==== Message Type Overview
 
-Sparkplug™ defines the Topic Namespace for set of MQTT messages that are used to manage connection state as well as bidirectional metric information exchange that would apply to many typical real-time SCADA/IIoT, monitoring, and data collection system use cases. The defined message types include:
+Sparkplug defines the Topic Namespace for set of MQTT messages that are used to manage connection state as well as bidirectional metric information exchange that would apply to many typical real-time SCADA/IIoT, monitoring, and data collection system use cases. The defined message types include:
 
 * *NBIRTH* – Birth certificate for MQTT EoN nodes.
 * *NDEATH* – Death certificate for MQTT EoN nodes.
@@ -171,7 +171,7 @@ The payload of DDATA messages can contain one or more metric values that need to
 [[topics_death_message_ddeath]]
 ===== Death Message (DDEATH)
 
-The Sparkplug™ Topic Namespace for a device Death Certificate is:
+The Sparkplug Topic Namespace for a device Death Certificate is:
 [subs="quotes"]
   namespace/group_id/*DDEATH*/edge_node_id/device_id
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Message_Flow.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Message_Flow.adoc
@@ -35,7 +35,7 @@ The session diagram in Figure 3 - Host Session Establishment shows a very simple
 [arabic]
 . _Primary Application_ will try to create an MQTT Session using the MQTT CONNECT Control Packet (_refer to section 3.1 in the MQTT V3.1.1 specification_). A Death Certificate is constructed into the Will Topic and Will Payload of the of the Connect Control Packet with a Will QoS = 1 and Will Retain = true. The MQTT CONNECT Control Packet is acknowledged as successful with a valid CONNACK Control Packet. From this point forward in time, the MQTT Server is ready to deliver a Host Death Certificate any time the _Primary Application_ MQTT Client loses connectivity to the MQTT Server.
 . Once an MQTT Session has been established, _Primary Application_ will publish a new STATE message as defined in in section 7.5.1, _SCADA/IIoT_ Birth Certificate Payload. At this point, _Primary Application_ can update the MQTT Client metrics in the _Primary Application_ with a current state of ONLINE.
-. With the MQTT Session established, and a STATE Birth Certificate published, the _Primary Application_ will issue an MQTT subscription for the defined Sparkplug™ Topic Namespace. The _Primary Application_ is now ready to start receiving MQTT messages from any connected EoN node within the infrastructure. Since the _Primary Application_ is also relying on the MQTT Session to the MQTT Server(s), the availability of Servers to the _Primary Application_ is also being monitored and reflected in the MQTT Client metrics in the _Primary Application_.
+. With the MQTT Session established, and a STATE Birth Certificate published, the _Primary Application_ will issue an MQTT subscription for the defined Sparkplug Topic Namespace. The _Primary Application_ is now ready to start receiving MQTT messages from any connected EoN node within the infrastructure. Since the _Primary Application_ is also relying on the MQTT Session to the MQTT Server(s), the availability of Servers to the _Primary Application_ is also being monitored and reflected in the MQTT Client metrics in the _Primary Application_.
 . If at any point in time _Primary Application_ loses connectivity with the defined MQTT Server(s), the ONLINE state of the Server is immediately reflected in the MQTT Client metrics in the _Primary Application_. All metric data associated with any MQTT EoN node that was connected to that MQTT Server will be updated to a "*STALE*" data quality.
 
 [[message_flow_eon_session_establishment]]
@@ -59,15 +59,15 @@ The session diagram in Figure 4 - EoN node MQTT Session Establishment shows a ve
 [[message_flow_device_sensor_session_establishment]]
 === Device / Sensor Session Establishment
 
-The Sparkplug™ specification is provided to get real time process variable information from existing and new end devices measuring, monitoring and controlling a physical process into an MQTT MOM infrastructure and the _Primary Application_ Industrial Internet of Things application platform. In the context of this document an MQTT Device can represent anything from existing legacy poll/response driven PLCs, RTUs, HART Smart Transmitter, etc., to new generation automation and instrumentation devices that can implement a conformant MQTT client natively.
+The Sparkplug specification is provided to get real time process variable information from existing and new end devices measuring, monitoring and controlling a physical process into an MQTT MOM infrastructure and the _Primary Application_ Industrial Internet of Things application platform. In the context of this document an MQTT Device can represent anything from existing legacy poll/response driven PLCs, RTUs, HART Smart Transmitter, etc., to new generation automation and instrumentation devices that can implement a conformant MQTT client natively.
 
-The preceding sections in this document detail how the _Primary Application_ interacts with the _MQTT Server infrastructure_ and how that infrastructure interacts with the notion of an MQTT EoN node. But to a large extent the technical requirements of those pieces of the infrastructure have already been provided. For most use cases in this market sector the primary focus will be on the implementation of the Sparkplug™ specification between the native device and the EoN node API’s.
+The preceding sections in this document detail how the _Primary Application_ interacts with the _MQTT Server infrastructure_ and how that infrastructure interacts with the notion of an MQTT EoN node. But to a large extent the technical requirements of those pieces of the infrastructure have already been provided. For most use cases in this market sector the primary focus will be on the implementation of the Sparkplug specification between the native device and the EoN node API’s.
 
 In order to expose and populate the metrics from any intelligent device, the following simple session diagram outlines the requirements:
 
 image:extracted-media/media/image9.png[image,width=660,height=309]Figure 5 - MQTT Device Session Establishment
 
-The session diagram in Figure 5 - MQTT Device Session Establishment shows a simple topology with all the Sparkplug™ elements in place i.e. _Primary Application_, MQTT Server(s), MQTT EoN node and this element, the device element. The steps outlined in the session diagram are defined as follows:
+The session diagram in Figure 5 - MQTT Device Session Establishment shows a simple topology with all the Sparkplug elements in place i.e. _Primary Application_, MQTT Server(s), MQTT EoN node and this element, the device element. The steps outlined in the session diagram are defined as follows:
 
 This flow diagram assumes that at least one MQTT Server is available and operational within the infrastructure. Without at least a single MQTT Server the remainder of the infrastructure is unavailable.
 
@@ -75,10 +75,10 @@ This flow diagram assumes that at least one MQTT Server is available and operati
 . Assuming MQTT Server is available.
 . Assuming the _Primary Application_ established MQTT Session with the MQTT Server(s).
 . The Session Establishment of the associated MQTT EoN node is described in section 8.2, EoN node Session Establishment. This flow diagram assumes that the EoN node session has already been established with the _Primary Application_. Depending on the target platform, the EoN node may be a physical "Edge of Network" gateway device polling physical legacy devices via Modbus, AB, DNP3.0, HART, etc., a MQTT enabled sensor or device, or it might be a logical implementation of one of the Eclipse Tahu reference implementations for prototype EoN nodes running on the Raspberry PI platform. Regardless of the implementation, at some point the device interface will need to provide a state and associated metrics to publish to the MQTT infrastructure.
-. State #4 in the session diagram represents the state at which the device is ready to report all of its metric information to the MQTT EoN node as defined in Sparkplug™. It is the responsibility of the EoN node (logical or physical) to put this information in a form defined in 0,
+. State #4 in the session diagram represents the state at which the device is ready to report all of its metric information to the MQTT EoN node as defined in Sparkplug. It is the responsibility of the EoN node (logical or physical) to put this information in a form defined in 0,
 . {blank}
 . Device Birth Certificate (DBIRTH). Upon receiving the DBIRTH message, the _Primary Application_ can build out the proper metric structure.
-. Following the Sparkplug™ specification in section 7.4, Device Data Messages (DDATA), all subsequent metrics are published to the _Primary Application_ on a Report by Exception (RBE) basis using the DDATA message format.
+. Following the Sparkplug specification in section 7.4, Device Data Messages (DDATA), all subsequent metrics are published to the _Primary Application_ on a Report by Exception (RBE) basis using the DDATA message format.
 . In at any time the device (logical or physical) cannot provide real time information, the MQTT EoN node specification requires that an DDEATH be published. This will inform the _Primary Application_ that all metric information be set to a "*STALE*" data quality.
 
 [[message_flow_general_mqtt_application_and_non_primary_applications]]
@@ -114,7 +114,7 @@ Figure 7 – Primary Application STATE flow diagram
 [[message_flow_eon_ndata_and_ncmd_messages]]
 === EoN NDATA and NCMD Messages
 
-We’ll start this section with a description of how metric information is published to the _Primary Application_ from an EoN node in the MQTT infrastructure. The definition of an EoN node is generic in that it can represent both physical "Edge of Network Gateway" devices that are interfacing with existing legacy equipment and a logical MQTT endpoint for devices that natively implement the Sparkplug™ specification. Section 7.4.1 above defines the Birth Certificate MQTT Payload and the fact that it can provide any number of metrics that will be exposed in the _Primary Application_. Some of these will be "read only" such as:
+We’ll start this section with a description of how metric information is published to the _Primary Application_ from an EoN node in the MQTT infrastructure. The definition of an EoN node is generic in that it can represent both physical "Edge of Network Gateway" devices that are interfacing with existing legacy equipment and a logical MQTT endpoint for devices that natively implement the Sparkplug specification. Section 7.4.1 above defines the Birth Certificate MQTT Payload and the fact that it can provide any number of metrics that will be exposed in the _Primary Application_. Some of these will be "read only" such as:
 
 * EoN Manufacture ID
 * EoN Device Type

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -21,9 +21,9 @@ infrastructure standpoint, the payload is treated as an agnostic binary array of
 from no payload at all, to a maximum of 256MB. But for applications within a known solution space to work 
 using MQTT the payload representation does need to be defined.
 
-This section of the Sparkplug™ specification defines how an MQTT Sparkplug™ payloads are encoded and the data 
-that is required. Note that Sparkplug™ supports multiple payloads encoding definitions. For more detailed 
-information on the payload formats and encoding associated with each Sparkplug™ release see the following 
+This section of the Sparkplug™ specification defines how an MQTT Sparkplug payloads are encoded and the data 
+that is required. Note that Sparkplug supports multiple payloads encoding definitions. For more detailed 
+information on the payload formats and encoding associated with each Sparkplug release see the following 
 sections.
 
 .. Sparkplug A Data Spec (TODO)
@@ -57,22 +57,22 @@ Additional information on Google Protocol Buffers can be found at:
 https://developers.google.com/protocol-buffers/
 
 [[payloads_sparkplug_a_mqtt_payload_definition]]
-=== Sparkplug™ A MQTT Payload Definition
+=== Sparkplug A MQTT Payload Definition
 TODO: Github Issue #55
 
 [[payloads_sparkplug_b_mqtt_payload_definition]]
-=== Sparkplug™ B MQTT Payload Definition
+=== Sparkplug B MQTT Payload Definition
 
-The goal of the Sparkplug™ is to provide a specification that both OEM device manufactures and application 
+The goal of the Sparkplug is to provide a specification that both OEM device manufactures and application 
 developers can use to create rich and interoperable SCADA/IIoT solutions using MQTT as a base messaging 
-technology. In Sparkplug™ B message payload definition, the goal was to create a simple and straightforward 
+technology. In Sparkplug B message payload definition, the goal was to create a simple and straightforward 
 binary message encoding that could be used primarily for legacy register based process variables (Modbus 
 register value for example).
 
-The Sparkplug™ B MQTT payload specification has come about based on the feedback from many system integrators 
+The Sparkplug B MQTT payload specification has come about based on the feedback from many system integrators 
 and end user customers who wanted to be able to natively support a much richer data model within the MQTT 
 infrastructures that they were designing and deploying. Using the feedback from the user community 
-Sparkplug™ B provides support for:
+Sparkplug B provides support for:
 
 * Complex data types using templates.
 * Datasets.
@@ -81,7 +81,7 @@ Sparkplug™ B provides support for:
 * Historical data.
 * File data.
 
-Sparkplug™ B definition creates a bandwidth efficient data transport for real time device data. For WAN based 
+Sparkplug B definition creates a bandwidth efficient data transport for real time device data. For WAN based 
 SCADA/IIoT infrastructures this equates to lower latency data updates while minimizing the amount of traffic 
 and therefore cellular and/or VSAT bandwidth required. In situations where bandwidth savings is not the 
 primary concern, the efficient use enables higher throughput of more and interesting data eliminating sensor 
@@ -90,14 +90,14 @@ to higher throughput of real time data to consumer applications without requirin
 topologies and/or equipment.
 
 There are many data encoding technologies available that can all be used in conjunction with MQTT. 
-Sparkplug™ B selected an existing, open, and highly available encoding scheme that efficiently encodes 
-register based process variables. The encoding technology selected for Sparkplug™ B is Google Protocol 
+Sparkplug B selected an existing, open, and highly available encoding scheme that efficiently encodes 
+register based process variables. The encoding technology selected for Sparkplug B is Google Protocol 
 Buffers also referred to as *Google* *_Protobufs_*.
 
 [[payloads_google_protocol_buffer_schema]]
 ==== Google Protocol Buffer Schema
 
-Using lessons learned on the feedback from the Sparkplug™ A implementation a new Google Protocol Buffer 
+Using lessons learned on the feedback from the Sparkplug A implementation a new Google Protocol Buffer 
 schema was developed that could be used to represent and encode the more complex data models being 
 requested. The entire Google Protocol Buffers definition is below.
 
@@ -315,10 +315,10 @@ message Payload {
 [[payloads_payload_metric_naming_convention]]
 === Payload Metric Naming Convention
 
-For the remainder of this document JSON will be used to represent components of a Sparkplug™ B payload. It 
+For the remainder of this document JSON will be used to represent components of a Sparkplug B payload. It 
 is important to note that the payload is a binary encoding and is not actually JSON. However, JSON 
 representation is used in this document to represent the payloads in a way that is easy to read. For 
-example, a simple Sparkplug™ B payload with a single metric can be represented in JSON as follows:
+example, a simple Sparkplug B payload with a single metric can be represented in JSON as follows:
 
 ----
 {
@@ -334,7 +334,7 @@ example, a simple Sparkplug™ B payload with a single metric can be represented
 }
 ----
 
-A simple Sparkplug™ B payload with values would be represented as follows:
+A simple Sparkplug B payload with values would be represented as follows:
 
 ----
 {
@@ -364,25 +364,25 @@ image:extracted-media/media/image12.png[image,width=638,height=139]
 Figure 8 – Payload Metric Folder Structure
 
 [[payloads_sparkplug_bv1_0_payload_components]]
-== Sparkplug™ Bv1.0 Payload Components
+== Sparkplug Bv1.0 Payload Components
 
-The Sparkplug™ specification document “*_MQTT Topic Namespace and State Management_*” document defines the 
-Topic Namespace that Sparkplug™ uses to publish and subscribe between EoN nodes and applications within the 
+The Sparkplug specification document “*_MQTT Topic Namespace and State Management_*” document defines the 
+Topic Namespace that Sparkplug uses to publish and subscribe between EoN nodes and applications within the 
 MQTT infrastructure. Using that Topic Namespace, this section of the specification defines the actual 
-payload contents of each message type in Sparkplug™ Bv1.0.
+payload contents of each message type in Sparkplug Bv1.0.
 
 [[payloads_payload_component_definitions]]
 === Payload Component Definitions
 
-Sparkplug™ B consists of a series of one or more metrics with metadata surrounding those metrics. The 
+Sparkplug B consists of a series of one or more metrics with metadata surrounding those metrics. The 
 following definitions explain the components that make up a payload.
 
 [[payloads_payload]]
 ==== Payload
 
-A Sparkplug™ B payload is the top-level component that is encoded and used in an MQTT message. It contains 
+A Sparkplug B payload is the top-level component that is encoded and used in an MQTT message. It contains 
 some basic information such as a timestamp and a sequence number as well as an array of metrics which 
-contain key/value pairs of data. A Sparkplug™ B payload includes the following components.
+contain key/value pairs of data. A Sparkplug B payload includes the following components.
 
 * *payload*
 ** _timestamp_
@@ -394,7 +394,7 @@ represent the time at which the message was published.
 section 3.1.2.
 ** _seq_
 *** This is the sequence number which is an unsigned 64-bit integer. A sequence number must be included in 
-the payload of every Sparkplug™ MQTT message. A NBIRTH message must always contain a sequence number of 
+the payload of every Sparkplug MQTT message. A NBIRTH message must always contain a sequence number of 
 zero. All subsequent messages must contain a sequence number that is continually increasing by one in each 
 message until a value of 255 is reached. At that point, the sequence number of the following message must 
 be zero.
@@ -408,7 +408,7 @@ bytes associated with a payload.
 [[payloads_metric]]
 ==== Metric
 
-A Sparkplug™ B metric is a core component of data in the payload. It represents a key/value/datatype along 
+A Sparkplug B metric is a core component of data in the payload. It represents a key/value/datatype along 
 with metadata used to describe the information it contains. It includes the following components.
 
 * *name*
@@ -418,7 +418,7 @@ example, ‘outputs/A’ would be a metric with a unique identifier of ‘A’ i
 limit to the number of folders. However, across the infrastructure of MQTT publishers a defined folder 
 should always remain a folder.
 * *alias*
-** This is an unsigned 64-bit integer representing an optional alias for a Sparkplug™ B payload. If supplied 
+** This is an unsigned 64-bit integer representing an optional alias for a Sparkplug B payload. If supplied 
 in an NBIRTH or DBIRTH it must be a unique number across this EoN nodes entire set of metrics. In other 
 words, no two metrics for the same EoN node can have the same alias. Upon being defined in the NBIRTH or 
 DBIRTH, subsequent messages can supply only the alias instead of the metric friendly name to reduce overall 
@@ -429,7 +429,7 @@ since epoch (Jan 1, 1970). It is highly recommended that this time is in UTC. Th
 represent the time at which the value of a metric was captured.
 * *datatype*
 ** This is an unsigned 32-bit integer representing the datatype. Datatypes are not explicitly defined in 
-the Sparkplug™ B Protobuf definition. Instead they are defined in section 4 of this document.
+the Sparkplug B Protobuf definition. Instead they are defined in section 4 of this document.
 * *is_historical*
 ** This is a Boolean flag which denotes whether this metric represents a historical value. In some cases, 
 it may be desirable to send metrics after they were acquired on a device or EoN node. This can be done for 
@@ -440,7 +440,7 @@ denotes that the message should not be considered a real time/current value.
 metrics can be considered those that are of interest to a back-end application(s) but shouldn’t be stored 
 in a historian on the backend.
 * *is_null*
-** This is a Boolean flag which denotes whether this metric has a null value. This is Sparkplug™ B’s 
+** This is a Boolean flag which denotes whether this metric has a null value. This is Sparkplug B’s 
 mechanism of explicitly denoting a metric’s value is actually null.
 * *metadata*
 ** This is a MetaData object associated with the metric for dealing with more complex datatypes. This is 
@@ -474,7 +474,7 @@ be omitted altogether.
 [[payloads_metadata]]
 ==== MetaData
 
-A Sparkplug™ B MetaData object is used to describe different types of binary data. It includes the 
+A Sparkplug B MetaData object is used to describe different types of binary data. It includes the 
 following components.
 
 * *is_multi_part*
@@ -504,7 +504,7 @@ subscriber.
 [[payloads_propertyset]]
 ==== PropertySet
 
-A Sparkplug™ B PropertySet object is used with a metric to add custom properties to the object. The 
+A Sparkplug B PropertySet object is used with a metric to add custom properties to the object. The 
 PropertySet is a map expressed as two arrays of equal size, one containing the keys and one containing the 
 values. It includes the following components.
 
@@ -518,14 +518,14 @@ It must contain the same number of items that are in the keys array.
 [[payloads_propertyvalue]]
 ==== PropertyValue
 
-A Sparkplug™ B PropertyValue object is used to encode the value and datatype of the value of a property in 
+A Sparkplug B PropertyValue object is used to encode the value and datatype of the value of a property in 
 a PropertySet. It includes the following components.
 
 * *type*
 ** This is an unsigned 32-bit integer representing the datatype of the value. Datatypes are not explicitly 
-defined in the Sparkplug™ B Protobuf definition. Instead they are defined in section 4 of this document.
+defined in the Sparkplug B Protobuf definition. Instead they are defined in section 4 of this document.
 * *is_null*
-** This is a Boolean flag which denotes whether this property has a null value. This is Sparkplug™ B’s 
+** This is a Boolean flag which denotes whether this property has a null value. This is Sparkplug B’s 
 mechanism of explicitly denoting a property’s value is actually null.
 * *value*
 ** The value of a property utilizes the ‘oneof’ mechanism of Google Protocol Buffers. The value supplied 
@@ -551,7 +551,7 @@ can be omitted altogether.
 [[payloads_propertysetlist]]
 ==== PropertySetList
 
-A Sparkplug™ B PropertySetList object is an array of PropertySet objects. It includes the following 
+A Sparkplug B PropertySetList object is an array of PropertySet objects. It includes the following 
 components.
 
 * *propertyset*
@@ -560,7 +560,7 @@ components.
 [[payloads_dataset]]
 ==== DataSet
 
-A Sparkplug™ B DataSet object is used to encode matrices of data. It includes the following components.
+A Sparkplug B DataSet object is used to encode matrices of data. It includes the following components.
 
 * *num_of_columns*
 ** This is an unsigned 64-bit integer representing the number of columns in this DataSet.
@@ -570,7 +570,7 @@ of elements that the types array contains.
 * *types*
 ** This is an array of unsigned 32 bit integers representing the datatypes of the columns. It must have the 
 same number of elements that the columns array contains. Datatypes are not explicitly defined in the 
-Sparkplug™ B Protobuf definition. Instead they are defined in section 4 of this document.
+Sparkplug B Protobuf definition. Instead they are defined in section 4 of this document.
 * *rows*
 ** This is an array of DataSet.Row objects. It contains the data that makes up the data rows of this 
 DataSet.
@@ -578,7 +578,7 @@ DataSet.
 [[payloads_dataset_row]]
 ==== DataSet.Row
 
-A Sparkplug™ B DataSet.Row object represents a row of data in a DataSet. It includes the following 
+A Sparkplug B DataSet.Row object represents a row of data in a DataSet. It includes the following 
 components.
 
 * *elements*
@@ -607,7 +607,7 @@ supplied with a DataSet.DataSetValue must be one of the following types.
 [[payloads_template]]
 ==== Template
 
-A Sparkplug™ B Template is used for encoding complex datatypes in a payload. It is a type of metric and can 
+A Sparkplug B Template is used for encoding complex datatypes in a payload. It is a type of metric and can 
 be used to create custom datatype definitions and instances. It includes the following components.
 
 * *version*
@@ -627,7 +627,7 @@ this is a definition. If false, this is an instance.
 [[payloads_template_parameter]]
 ==== Template.Parameter
 
-A Sparkplug™ B Template.Parameter is a metadata field for a Template. This can be used to represent 
+A Sparkplug B Template.Parameter is a metadata field for a Template. This can be used to represent 
 parameters that are common across a Template but the values are unique to the Template instances. It 
 includes the following components.
 
@@ -635,7 +635,7 @@ includes the following components.
 ** This is a UTF-8 string representing the name of the Template parameter.
 * *type*
 ** This is an unsigned 32-bit integer representing the datatype of the template parameter. Datatypes are 
-not explicitly defined in the Sparkplug™ B Protobuf definition. Instead they are defined in section 4 of 
+not explicitly defined in the Sparkplug B Protobuf definition. Instead they are defined in section 4 of 
 this document.
 * *value*
 ** The value of a template parameter utilizes the ‘oneof’ mechanism of Google Protocol Buffers. The value 
@@ -655,9 +655,9 @@ parameter. For a template instance, this is the value unique to that instance.
 **** Defined here: https://developers.google.com/protocol-buffers/docs/proto#scalar
 
 [[payloads_sparkplug_bv1_0_payload_datatypes]]
-=== Sparkplug™ Bv1.0 Payload Datatypes
+=== Sparkplug Bv1.0 Payload Datatypes
 
-The Sparkplug™ B Google Protocol Buffers definition intentionally excludes datatypes in the definition. 
+The Sparkplug B Google Protocol Buffers definition intentionally excludes datatypes in the definition. 
 Different applications and systems have a wide variety of datatypes. As a result, Sparkplug B left them 
 out and instead defines them in the client libraries. This allows consuming applications to be more dynamic 
 in terms of adding new datatypes or even defining custom datatypes.
@@ -703,7 +703,7 @@ in terms of adding new datatypes or even defining custom datatypes.
 ** _Float_
 *** 32-bit floating point number
 *** Google Protocol Buffer Type: float
-*** Sparkplug™ enum value: 9
+*** Sparkplug enum value: 9
 ** _Double_
 *** 64-bit floating point number
 *** Google Protocol Buffer Type: double
@@ -944,7 +944,7 @@ in terms of adding new datatypes or even defining custom datatypes.
 * _Text_
 ** String value (UTF-8)
 ** Google Protocol Buffer Type: string
-** Sparkplug™ enum value: 14
+** Sparkplug enum value: 14
 
 [[payloads_payloads_by_message_type]]
 == Payloads by Message Type
@@ -1095,13 +1095,13 @@ of the following:
 * ONLINE
 ** If the application is connected
 
-Sparkplug™ B payloads are not used for encoding in this payload. This allows critical/backend application(s) 
+Sparkplug B payloads are not used for encoding in this payload. This allows critical/backend application(s) 
 to work across Sparkplug payload types.
 
 [[payloads_payload_representation_on_backend_applications]]
 == Payload Representation on Backend Applications
 
-Sparkplug™ B payloads in conjunction with the Sparkplug topic namespace result in hierarchical data 
+Sparkplug B payloads in conjunction with the Sparkplug topic namespace result in hierarchical data 
 structures that can be represented in folder structures with metrics which are often called tags.
 
 [[payloads_nbirth]]


### PR DESCRIPTION
Remove all instances of the TM symbol except the first mention in each chapter.  One added mention of Eclipse for the very first mention of Sparkplug in the document.