### PR TITLE
Add ReceiveData test and general listener

### DIFF
--- a/MQTTListener.sh
+++ b/MQTTListener.sh
@@ -1,0 +1,1 @@
+java -classpath tck/build/hivemq-extension/sparkplug-tck-3.0.0-SNAPSHOT.jar:tahu-java-0.5.13-SNAPSHOT.jar:org.eclipse.paho.client.mqttv3-1.2.5.jar:./slf4j-log4j12-1.7.5.jar:./log4j-1.2.17.jar  org.eclipse.sparkplug.tck.test.MQTTListener

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/ConnectInterceptor.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/ConnectInterceptor.java
@@ -34,7 +34,7 @@ public class ConnectInterceptor implements ConnectInboundInterceptor {
 		try {
 			String clientId = connectInboundInput.getClientInformation().getClientId();
 					
-			logger.debug("Inbound connect from '{}'", clientId);
+			logger.info("Inbound connect from '{}'", clientId);
 			logger.debug("\tInet Address {}", connectInboundInput.getConnectionInformation().getInetAddress());
 			logger.debug("\tMQTT Version {}", connectInboundInput.getConnectionInformation().getMqttVersion());
 			logger.debug("\tClean Start {}", connectInboundInput.getConnectPacket().getCleanStart());

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/PublishInterceptor.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/PublishInterceptor.java
@@ -42,12 +42,12 @@ public class PublishInterceptor implements PublishInboundInterceptor {
 			@NotNull PublishInboundOutput publishInboundOutput) {
 		try {
 			String clientId = publishInboundInput.getClientInformation().getClientId();
-			logger.debug("Inbound publish from '{}'", clientId);
+			logger.info("Inbound publish from '{}'", clientId);
 					
 			PublishPacket packet = publishInboundInput.getPublishPacket();
 			
 			String topic = packet.getTopic();
-			logger.debug("\tTopic {}", topic);
+			logger.info("\tTopic {}", topic);
 			
 			String payload = null;
 			ByteBuffer bpayload = packet.getPayload().orElseGet(null);
@@ -85,6 +85,8 @@ public class PublishInterceptor implements PublishInboundInterceptor {
 			
 		} catch (Exception e) {
 			logger.error("Exception", e);
+		} catch (Error e) {
+			System.out.println("Error");
 		}
 	}
 }

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/MQTTListener.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/MQTTListener.java
@@ -1,0 +1,148 @@
+/********************************************************************************
+ * Copyright (c) 2014, 2021 Cirrus Link Solutions and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Cirrus Link Solutions - initial implementation
+ *   Ian Craggs - add checks for Sparkplug TCK
+ ********************************************************************************/
+
+package org.eclipse.sparkplug.tck.test;
+
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.MqttTopic;
+import org.eclipse.tahu.message.SparkplugBPayloadDecoder;
+import org.eclipse.tahu.message.model.SparkplugBPayload;
+import org.eclipse.tahu.message.model.Topic;
+import org.eclipse.tahu.util.TopicUtil;
+
+import org.eclipse.sparkplug.tck.sparkplug.Sections;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpecVersion(
+        spec = "sparkplug",
+        version = "3.0.0-SNAPSHOT")
+public class MQTTListener implements MqttCallbackExtended {
+
+	// Configuration
+	private String serverUrl = "tcp://localhost:1883";
+	private String clientId = "Sparkplug MQTT Listener";
+	private String username = "admin";
+	private String password = "changeme";
+	private String log_topic_name = "SPARKPLUG_TCK/LOG";
+	private MqttTopic log_topic = null;
+	private MqttClient client;
+	
+	public void log(String message) {
+		try {
+			MqttMessage mqttmessage = new MqttMessage(message.getBytes());
+			log_topic.publish(mqttmessage);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public static void main(String[] args) {
+		MQTTListener listener = new MQTTListener();
+		listener.run();
+	}
+	
+	public void run() {
+		System.out.println("*** Sparkplug TCK MQTT Listener ***");
+		try {
+			// Connect to the MQTT Server
+			MqttConnectOptions options = new MqttConnectOptions();
+			options.setAutomaticReconnect(true);
+			options.setCleanSession(true);
+			options.setConnectionTimeout(30);
+			options.setKeepAliveInterval(30);
+			//options.setUserName(username);
+			//options.setPassword(password.toCharArray());
+			client = new MqttClient(serverUrl, clientId);
+			client.setTimeToWait(5000);						// short timeout on failure to connect
+			client.setCallback(this);
+			log_topic = client.getTopic(log_topic_name);
+			client.connect(options);
+			
+			// Just listen to all DDATA messages on spBv1.0 topics and wait for inbound messages
+			client.subscribe(new String[]{"spBv1.0/#", "STATE/#"}, new int[]{2, 2});
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Override
+	public void connectComplete(boolean reconnect, String serverURI) {
+		System.out.println("Connected!");
+	}
+
+	@Override
+	public void connectionLost(Throwable cause) {
+		System.out.println("The MQTT Connection was lost! - will auto-reconnect");
+    }
+
+	@Override
+	public void messageArrived(String topic, MqttMessage message) throws Exception {
+		Topic sparkplugTopic = TopicUtil.parseTopic(topic);
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		
+		System.out.println("Message Arrived on Sparkplug topic " + sparkplugTopic.toString());
+		
+		SparkplugBPayloadDecoder decoder = new SparkplugBPayloadDecoder();
+		SparkplugBPayload inboundPayload = decoder.buildFromByteArray(message.getPayload());
+		
+		// Convert the message to JSON and print to system.out
+		try {
+			String payloadString = mapper.writeValueAsString(inboundPayload);
+			System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(inboundPayload));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void deliveryComplete(IMqttDeliveryToken token) {
+		System.out.println("Published message: " + token);
+	}
+	
+    @SpecAssertion(
+    		section = Sections.TOPICS_SPARKPLUG_TOPIC_NAMESPACE_ELEMENTS,
+    		id = "topic-structure")
+    @SpecAssertion(
+    		section = Sections.INTRODUCTION_SPARKPLUG_IDS,
+    		id = "intro-group-id-string")
+	public void checkTopic(String[] elements) {
+		if (elements[0].equals("STATE")) {
+			
+		} else {
+			if (elements.length < 4) {
+				log("topic-structure: FAIL (too few topic elements)");
+			} else {
+				String namespace = elements[0];
+				String group_id = elements[1];
+				String message_type = elements[2];
+				String edge_node_id = elements[3];
+				String device_id = elements[4];
+			}
+		}
+	}
+    
+    public void checkMQTTChars(String string) {
+    	
+    }
+    
+}

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCKTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCKTest.java
@@ -27,6 +27,7 @@ import com.hivemq.extension.sdk.api.packets.general.Qos;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.lang.System;
 
 public abstract class TCKTest {
 	
@@ -51,7 +52,7 @@ public abstract class TCKTest {
 		    payload.append(key);
 		    payload.append(": ");
 		    payload.append(result);
-		    payload.append("; ");
+		    payload.append(";"+System.lineSeparator());
 		    
 		    if (!result.equals("PASS")) {
 		    	overall = "FAIL";
@@ -60,7 +61,7 @@ public abstract class TCKTest {
 		
 	    payload.append("OVERALL: ");
 	    payload.append(overall);
-	    payload.append("; ");
+	    payload.append(";"+System.lineSeparator());
 	    
 	    logger.info("Test results "+payload.toString());
 		

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/ReceiveDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/ReceiveDataTest.java
@@ -17,9 +17,10 @@ package org.eclipse.sparkplug.tck.test.host;
  * This is the primary host Sparkplug receive data test.  Data can be received from edge
  * nodes and devices.
  * 
- * We can manufacture some data events to be received by the primary host.
- * But how do we verify that they have been handled correctly?  Can we rely on the
- * user running the tests to report the results accurately?
+ * We manufacture some data events to be received by the primary host.
+ * 
+ * To verify that they have been handled correctly, we have to rely on the
+ * user running the tests to report the results.
  * 
  */
 
@@ -31,6 +32,11 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
 import com.hivemq.extension.sdk.api.packets.publish.PublishPacket;
 import com.hivemq.extension.sdk.api.packets.connect.WillPublishPacket;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
+import com.hivemq.extension.sdk.api.services.publish.RetainedPublish;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.publish.PublishService;
+import com.hivemq.extension.sdk.api.services.publish.Publish;
+import com.hivemq.extension.sdk.api.services.builder.Builders;
 
 import org.eclipse.sparkplug.tck.sparkplug.Sections;
 import org.eclipse.sparkplug.tck.test.TCK;
@@ -44,6 +50,8 @@ import java.util.HashMap;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @SpecVersion(
         spec = "sparkplug",
@@ -51,6 +59,9 @@ import java.nio.ByteBuffer;
 public class ReceiveDataTest extends TCKTest {
 
     private static Logger logger = LoggerFactory.getLogger("Sparkplug");
+    private String edge_metric = "TCK_metric/Int32";
+    private String device_metric = "Inputs/0";
+        
     private HashMap testResults = new HashMap<String, String>();
     String[] testIds = {
     	"",
@@ -58,7 +69,11 @@ public class ReceiveDataTest extends TCKTest {
     private String myClientId = null;
     private String state = null;
     private TCK theTCK = null;
+    
     private String host_application_id = null;
+    private String edge_node_id = null;
+    private String device_id = null;
+	private PublishService publishService = Services.publishService();
     
     public ReceiveDataTest(TCK aTCK, String[] parms) {
         logger.info("Primary host receive data test");
@@ -72,6 +87,64 @@ public class ReceiveDataTest extends TCKTest {
         
         host_application_id = parms[0];
         logger.info("Host application id is "+host_application_id);
+        
+        if (parms.length < 3) {
+        	logger.info("Parameters to receive data test must be: host_application_id edge_node_id device_id");
+        	return;
+        }
+        host_application_id = parms[0];
+        logger.info("Host application id is "+host_application_id);
+        
+        boolean host_online = false;
+        String topic = "STATE/"+host_application_id;
+        // Check that the host application status is ONLINE, ready for the test
+        final CompletableFuture<Optional<RetainedPublish>> getFuture = Services.retainedMessageStore().getRetainedMessage(topic);
+        
+        try {
+        	Optional<RetainedPublish> retainedPublishOptional = getFuture.get();
+        	if (retainedPublishOptional.isPresent()) {
+        		final RetainedPublish retainedPublish = retainedPublishOptional.get();
+    			String payload = null;
+        		ByteBuffer bpayload = retainedPublish.getPayload().orElseGet(null);
+    			if (bpayload != null) {
+    				payload = StandardCharsets.UTF_8.decode(bpayload).toString();
+    			}
+        		if (!payload.equals("ONLINE")) {
+        			logger.info("Host status payload: " + payload);
+        		} else {
+        			host_online = true;
+        		}
+        	}
+        	else {
+        		logger.info("No retained message for topic: " + topic);
+        	}
+        } catch (InterruptedException | ExecutionException e) {
+
+        }
+        
+        if (!host_online) { 
+        	logger.info("Host application not online - test not started.");
+        	return;
+        }
+        
+        edge_node_id = parms[1];
+        logger.info("Edge node id is "+edge_node_id);
+        
+        device_id = parms[2];
+        logger.info("Device id is "+device_id);
+        
+        // First we have to connect an edge node and device.
+        // We do this by sending an MQTT control message to the TCK device utility.
+        // ONLY DO THIS IF THE EDGE/DEVICE haven't already been created!!
+        state = "ConnectingDevice";
+        String payload = "NEW DEVICE "+host_application_id+" "+edge_node_id+" "+device_id;
+		Publish message = Builders.publish().topic("SPARKPLUG_TCK/DEVICE_CONTROL").qos(Qos.AT_LEAST_ONCE)
+				.payload(ByteBuffer.wrap(payload.getBytes()))
+				.build();
+		logger.info("Requesting new device creation.  Edge node id: "+edge_node_id + " device id: "+device_id);
+		publishService.publish(message);
+        
+        
     }
     
     public void endTest() {
@@ -109,8 +182,59 @@ public class ReceiveDataTest extends TCKTest {
 
 	@Override
 	public void publish(String clientId, PublishPacket packet) {
-		// TODO Auto-generated method stub
-		
+		if (packet.getTopic().equals("SPARKPLUG_TCK/LOG")) {
+			String payload = null;
+			ByteBuffer bpayload = packet.getPayload().orElseGet(null);
+			if (bpayload != null) {
+				payload = StandardCharsets.UTF_8.decode(bpayload).toString();
+			}
+			String[] words = payload.split(" ");
+			logger.info("Receive data test: "+words[0]+" "+words[1]);
+			
+			if (state.equals("ConnectingDevice") && payload.equals("Device "+device_id+" successfully created")) {
+				logger.info("ReceiveDataTest: Device was created");
+							
+		        // Now tell the device simulator to send some data from the edge node
+		        payload = "SEND_EDGE_DATA "+host_application_id+" "+edge_node_id+" "+edge_metric;
+				Publish message = Builders.publish().topic("SPARKPLUG_TCK/DEVICE_CONTROL").qos(Qos.AT_LEAST_ONCE)
+						.payload(ByteBuffer.wrap(payload.getBytes()))
+						.build();
+				logger.info("Requesting data from edge node id: "+edge_node_id + " metric: "+edge_metric);
+				publishService.publish(message);
+				state = "RequestedNodeData";
+				
+		        payload = "Data is being sent from edge node "+edge_node_id + " metric "+device_metric+".\n";
+		        payload += "Check that the value is updated on the host application";
+				message = Builders.publish().topic("SPARKPLUG_TCK/CONSOLE_PROMPT").qos(Qos.AT_LEAST_ONCE)
+						.payload(ByteBuffer.wrap(payload.getBytes()))
+						.build();
+				logger.info("Requesting edge node data check for edge id: "+edge_node_id);
+				publishService.publish(message);
+			}			
+			else if (state.equals("RequestedNodeData") && words[0].equals("CONSOLE_RESPONSE")) {
+				if (words[1].equals("OK")) {
+					
+					// Now tell the device simulator to send some data from the devoce
+			        payload = "SEND_DEVICE_DATA "+host_application_id+" "+edge_node_id+" "+device_id+" "+device_metric;
+					Publish message = Builders.publish().topic("SPARKPLUG_TCK/DEVICE_CONTROL").qos(Qos.AT_LEAST_ONCE)
+							.payload(ByteBuffer.wrap(payload.getBytes()))
+							.build();
+					logger.info("Requesting data from device id: "+device_id + " metric: "+device_metric);
+					publishService.publish(message);
+					state = "RequestedDeviceData";
+					
+			        payload = "Data is being sent from device "+device_id + " metric "+device_metric+".\n";
+			        payload += "Check that the value is updated on the host application";
+					message = Builders.publish().topic("SPARKPLUG_TCK/CONSOLE_PROMPT").qos(Qos.AT_LEAST_ONCE)
+							.payload(ByteBuffer.wrap(payload.getBytes()))
+							.build();
+					logger.info("Requesting device data check for device id: "+device_id);
+					publishService.publish(message);
+				}
+			}
+			else if (state.equals("RequestedDeviceData") && words[0].equals("CONSOLE_RESPONSE")) {
+				theTCK.endTest();
+			}
+		}
 	}
-
 }

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SendCommandTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SendCommandTest.java
@@ -81,19 +81,19 @@ public class SendCommandTest extends TCKTest {
     private static Logger logger = LoggerFactory.getLogger("Sparkplug");
     private HashMap testResults = new HashMap<String, String>();
     String[] testIds = {
-    	"topics_ncmd_mqtt",
-    	"topics_ncmd_timestamp",
-    	"topics_ncmd_payload",
-    	"topics_dcmd_mqtt",
-    	"topics_dcmd_timestamp",
-    	"topics_dcmd_payload"
+    	"topics-ncmd-mqtt",
+    	"topics-ncmd-timestamp",
+    	"topics-ncmd-payload",
+    	"topics-dcmd-mqtt",
+    	"topics-dcmd-timestamp",
+    	"topics-dcmd-payload"
     };
     private String myClientId = null;
     private String state = null;
     private TCK theTCK = null;
     private String host_application_id = null;
     private String edge_node_id = null;
-    private String edge_metric = "TCK_metric/0";
+    private String edge_metric = "TCK_metric/Boolean";
     private String device_id = null;
     private String device_metric = "Inputs/0";
 	private PublishService publishService = Services.publishService();
@@ -243,20 +243,20 @@ public class SendCommandTest extends TCKTest {
 	
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_NCMD,
-    		id = "topics_ncmd_mqtt") 
+    		id = "topics-ncmd-mqtt") 
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_NCMD,
-    		id = "topics_ncmd_timestamp")
+    		id = "topics-ncmd-timestamp")
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_NCMD,
-    		id = "topics_ncmd_payload")
+    		id = "topics-ncmd-payload")
 	public void checkNodeCommand(String clientId, PublishPacket packet) {
 		String result = "FAIL";
 		if (packet.getQos() == Qos.AT_MOST_ONCE && 
 				packet.getRetain() == false) {
 			result = "PASS";
 		}
-		testResults.put("topics_ncmd_mqtt", result);
+		testResults.put("topics-ncmd-mqtt", result);
 		
 		SparkplugBPayloadDecoder decoder = new SparkplugBPayloadDecoder();				
 		ByteBuffer bpayload = packet.getPayload().orElseGet(null);
@@ -280,7 +280,7 @@ public class SendCommandTest extends TCKTest {
 				result = "PASS";
 			}	
 		}
-		testResults.put("topics_ncmd_timestamp", result);
+		testResults.put("topics-ncmd-timestamp", result);
 		
 		result = "FAIL";
 		if (inboundPayload != null) {
@@ -293,26 +293,26 @@ public class SendCommandTest extends TCKTest {
 				}
 			}
 		}
-		testResults.put("topics_ncmd_payload", result);
+		testResults.put("topics-ncmd-payload", result);
 		logger.info("Send command test payload "+result);
 	}
 	
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_DCMD,
-    		id = "topics_dcmd_mqtt") 
+    		id = "topics-dcmd-mqtt") 
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_DCMD,
-    		id = "topics_dcmd_timestamp")
+    		id = "topics-dcmd-timestamp")
 	@SpecAssertion(
     		section = Sections.PAYLOADS_DESC_DCMD,
-    		id = "topics_dcmd_payload")
+    		id = "topics-dcmd-payload")
 	public void checkDeviceCommand(String clientId, PublishPacket packet) {
 		String result = "FAIL";
 		if (packet.getQos() == Qos.AT_MOST_ONCE && 
 				packet.getRetain() == false) {
 			result = "PASS";
 		}
-		testResults.put("topics_dcmd_mqtt", result);
+		testResults.put("topics-dcmd-mqtt", result);
 		
 		SparkplugBPayloadDecoder decoder = new SparkplugBPayloadDecoder();				
 		ByteBuffer bpayload = packet.getPayload().orElseGet(null);
@@ -336,7 +336,7 @@ public class SendCommandTest extends TCKTest {
 				result = "PASS";
 			}	
 		}
-		testResults.put("topics_dcmd_timestamp", result);
+		testResults.put("topics-dcmd-timestamp", result);
 		
 		// Check for metric Inputs/0
 		result = "FAIL";
@@ -350,7 +350,7 @@ public class SendCommandTest extends TCKTest {
 				}
 			}
 		}
-		testResults.put("topics_dcmd_payload", result);
+		testResults.put("topics-dcmd-payload", result);
 		logger.info("Send command test payload "+result);
 	}
 	

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionEstablishmentTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionEstablishmentTest.java
@@ -48,14 +48,14 @@ public class SessionEstablishmentTest extends TCKTest {
     private static Logger logger = LoggerFactory.getLogger("Sparkplug");
     private HashMap testResults = new HashMap<String, String>();
     String[] testIds = {
+    	"host-topic-phid-required",
     	"host-topic-phid-birth-payload",
     	"host-topic-phid-death-payload", 
     	"host-topic-phid-death-qos",
     	"host-topic-phid-death-retain",
-    	"primary-application-connect",
-    	"primary-application-death-cert",
-    	"primary-application-subscribe",
-    	"primary-application-state-publish",
+    	"host-topic-phid-death-payload-off",
+    	"message-flow-phid-sparkplug-subscription",
+    	"message-flow-phid-sparkplug-state-publish",
     	"components-ph-state"
     };
     private String myClientId = null;
@@ -102,6 +102,9 @@ public class SessionEstablishmentTest extends TCKTest {
     		section = Sections.TOPICS_DEATH_MESSAGE_STATE,
     		id = "host-topic-phid-death-payload")
     @SpecAssertion(
+    		section = Sections.PAYLOADS_DESC_STATE_DEATH,
+    		id = "host-topic-phid-death-payload-off")
+    @SpecAssertion(
     		section = Sections.TOPICS_DEATH_MESSAGE_STATE,
     		id = "host-topic-phid-death-qos")
     @SpecAssertion(
@@ -118,6 +121,7 @@ public class SessionEstablishmentTest extends TCKTest {
     			result = "PASS";
     		} 
     		testResults.put("host-topic-phid-death-payload", result);
+    		testResults.put("host-topic-phid-death-payload-off", result);
     		
     		result = "FAIL";
     		if (willPublishPacket.getQos() == Qos.AT_LEAST_ONCE) {
@@ -136,11 +140,8 @@ public class SessionEstablishmentTest extends TCKTest {
 
     @Test
     @SpecAssertion(
-            section = Sections.OPERATIONAL_BEHAVIOR_PRIMARY_HOST_APPLICATION_SESSION_ESTABLISHMENT,
-            id = "primary-application-connect")
-    @SpecAssertion(
-            section = Sections.OPERATIONAL_BEHAVIOR_PRIMARY_HOST_APPLICATION_SESSION_ESTABLISHMENT,
-            id = "primary-application-death-cert")          
+            section = Sections.TOPICS_DEATH_MESSAGE_STATE,
+            id = "host-topic-phid-required")          
     public void connect(String clientId, ConnectPacket packet) {
         logger.info("Primary host session establishment test - connect");
         
@@ -152,7 +153,7 @@ public class SessionEstablishmentTest extends TCKTest {
         	if (willPublishPacketOptional != null) {
         		result = "PASS";
         	}
-        	testResults.put("primary-application-death-cert", result);
+        	testResults.put("host-topic-phid-required", result);
         } catch (Exception e) {
         	logger.info("Exception", e);
         }
@@ -170,30 +171,28 @@ public class SessionEstablishmentTest extends TCKTest {
         	logger.info("Test failed "+e.getMessage());
         	result = "FAIL "+e.getMessage();
         }
-        testResults.put("primary-application-connect", result);
     }
     
     @Test
     @SpecAssertion(
             section = Sections.OPERATIONAL_BEHAVIOR_PRIMARY_HOST_APPLICATION_SESSION_ESTABLISHMENT,
-            id = "primary-application-subscribe")
+            id = "message-flow-phid-sparkplug-subscription")
     public void subscribe(String clientId, SubscribePacket packet) {
         logger.info("Primary host session establishment test - subscribe");
 
-        if (myClientId.equals(clientId)) {
+        if (myClientId.equals(clientId) && packet.getSubscriptions().get(0).getTopicFilter().equals("spAv1.0/#")) {
         	String result = "FAIL";
         	try {
         		if (!state.equals("CONNECTED"))
-        			throw new Exception("State should be connected");
-        		if (!packet.getSubscriptions().get(0).getTopicFilter().equals("spAv1.0/#"))
-        			throw new Exception("Topic string wrong");
+        			throw new Exception("State should be connected, is "+state);
+
         		// TODO: what else do we need to check?
         		result = "PASS";
          		state = "SUBSCRIBED";
         	} catch (Exception e) {
         		result = "FAIL "+e.getMessage();
         	}
-        	testResults.put("primary-application-subscribe", result);
+        	testResults.put("message-flow-phid-sparkplug-subscription", result);
         }
     }
 
@@ -203,7 +202,7 @@ public class SessionEstablishmentTest extends TCKTest {
     		id = "host-topic-phid-birth-payload")
     @SpecAssertion(
             section = Sections.OPERATIONAL_BEHAVIOR_PRIMARY_HOST_APPLICATION_SESSION_ESTABLISHMENT,
-            id = "primary-application-state-publish")
+            id = "message-flow-phid-sparkplug-state-publish")
     @SpecAssertion(
             section = Sections.COMPONENTS_PRIMARY_HOST_APPLICATION,
             id = "components-ph-state")
@@ -234,7 +233,7 @@ public class SessionEstablishmentTest extends TCKTest {
         	} catch (Exception e) {
         		result = "FAIL " + e.getMessage();
         	}
-        	testResults.put("primary-application-state-publish", result);
+        	testResults.put("message-flow-phid-sparkplug-state-publish", result);
         	testResults.put("host-topic-phid-birth-payload", result);
         	testResults.put("components-ph-state", result);
         }


### PR DESCRIPTION
This is a working (host application) receive data test - I used Ignition to verify it.

However, I don't see that there are corresponding assertions in the spec to add to this test.  Is this true?  As section 5.9, Data Publish is currently empty, then that might explain it?  

As this test is for receipt of edge and device data messages, the assertions would be on the Host Application side, such as "when the host application receives a data message from an edge node or device, the corresponding data in the host application should be updated ASAP", or similar.  What do you think?