### PR TITLE
Fixes #93 Added section to Chapter 5 to cover Host Application handling of out of order messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tck/src/license/THIRD-PARTY.properties
 build/
 target/
 specification/src/main/asciidoc/docinfo-header.html
+.settings

--- a/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
@@ -18,12 +18,13 @@ _Sparkplug™ and the Sparkplug™ logo are trademarks of the Eclipse Foundation
 [[conformance_profiles]]
 === Conformance Profiles
 
-There are three Sparkplug target applications. A Sparkplug infrastructure typically consists of one
+There are four Sparkplug target applications. A Sparkplug infrastructure typically consists of one
 or more of the following application types
 
 * Sparkplug Edge Node
 * Sparkplug Host Application
 * MQTT Server
+* Sparkplug Aware MQTT Server
 
 Each application type has specific conformance requirements that must be met. Typically a Sparkplug
 application would only implement one of these profiles. For example an MQTT client wouldn't
@@ -46,8 +47,8 @@ Nodes when required.
 [tck-testable tck-id-conformance-primary-host]#[yellow-background]*Sparkplug Host Applications MUST
 publish 'STATE' messages that represent its Birth and Death Certificates.*#
 
-[[conformance_sparkplug_mqtt_server]]
-==== Sparkplug MQTT Server
+[[conformance_mqtt_server]]
+==== MQTT Server
 
 Sparkplug infrastructures have a specific subset of requirements on MQTT Servers. Any fully MQTT
 v3.1.1 or v5.0 MQTT Server will meet the requirements of Sparkplug infrastructures. However, not all
@@ -63,7 +64,8 @@ MQTT Server MUST support all aspects of Will Messages including use of the 'reta
 * [tck-testable tck-id-conformance-mqtt-retained]#[yellow-background]*A Sparkplug conformant MQTT
 Server MUST support all aspects of the 'retain flag'*#
 
-
+[[conformance_sparkplug_aware_mqtt_server]]
+==== Sparkplug Aware MQTT Server
 
 
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -250,6 +250,49 @@ The only fundamental difference between a Primary Host Application MQTT Client a
 Host Application MQTT Clients is that the Edge Nodes in the infrastructure know to make sure the
 Primary Host Application is online before publishing data.
 
+[[operational_behavior_host_application_message_ordering]]
+=== Sparkplug Host Application Message Ordering
+
+Sparkplug Host Applications are required to validate the order of messages arriving from Edge Nodes.
+This is done using the sequence number which is sent in every NBIRTH, DBIRTH, NDATA, and DDATA
+message that comes from an Edge Node. Because these MQTT messages are sent on different topics, it
+is possible based on MQTT Server implementations that these messages may arrive at the Sparkplug
+Host Application in a different order than they were sent from the Edge Node. This can be especially
+common when using clustered MQTT Servers. It is the responsibility of the Sparkplug Host Application
+to ensure that all messages arrive within a 'Reorder Timeout'. In typical environments this timeout
+can be as little as a couple of seconds. In deployments with very slow networks or clustered MQTT
+servers it may need to be longer. In some environments, the MQTT Server may ensure in-order delivery
+of QoS0 MQTT messages even across topics. In these cases this timeout could be zero.
+
+If a Sparkplug Host Applications receives messages from Edge Node with sequence numbers 1, 2, and 4.
+At the time the message with a sequence number of 4 arrives, a timer SHOULD be started within the
+Host Application. This is the start of the Reordering Timeout timer. A messages with sequence number
+3 MUST arrive before the Reordering Timeout elapses. If a message with sequence number 3 does not
+arrive before the timeout, a Rebirth Request SHOULD be sent to the Edge Node. The ensures the
+session state is properly reestablished. If a message with a sequence number of 3 arrives before the
+Reorder Timeout occurs, the timer can be shutdown and normal operation of the Host Application can
+continue.
+
+It is also important to note that depending on the Sparkplug Host Application's purpose, it may make
+sense to never process messages out of order. It also may make sense to not process a message that
+arrived out of sequence if its preceding messages didn't arrive before the Reorder Timeout. These
+choices are left to the Sparkplug Host Application developer.
+
+* [tck-testable tck-id-operational-behavior-host-reordering-param]#[yellow-background]*Sparkplug
+Host Applications SHOULD provide a configurable 'Reorder Timeout' parameter*#
+* [tck-testable tck-id-operational-behavior-host-reordering-start]#[yellow-background]*If a message
+arrives with a out of order sequence number, the Host Application SHOULD start a timer denoting the
+start of the Reorder Timeout window*#
+* [tck-testable tck-id-operational-behavior-host-reordering-rebirth]#[yellow-background]*If the
+Reorder Timeout elapses and the missing message(s) have not been received, the Sparkplug Host
+Application SHOULD send an NCMD to the Edge Node with a 'Node Control/Rebirth' request*#
+** Non-normative comment: In most cases a 'Primary Host Application' would send a Rebirth Request
+but a Non-Primary Host may not
+* [tck-testable tck-id-operational-behavior-host-reordering-success]#[yellow-background]*If the
+missing messages that triggered the start of the Reorder Timeout timer arrive before the reordering
+timer elapses, the timer can be terminated and normal operation in the Host Application can
+continue*#
+
 [[operational_behavior_primary_application_state_in_multiple_mqtt_server_topologies]]
 === Primary Host Application STATE in Multiple MQTT Server Topologies
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -445,26 +445,38 @@ string. The slashes in the string represent folders of the metric to represent h
 structures. For example, ‘outputs/A’ would be a metric with a unique identifier of ‘A’ in the
 ‘outputs’ folder. There is no limit to the number of folders. However, across the infrastructure of
 MQTT publishers a defined folder should always remain a folder.
+** [tck-testable tck-id-payloads-name-requirement]#[yellow-background]*The name MUST be
+included with every metric unless aliases are being used.*#
 * *alias*
 ** This is an unsigned 64-bit integer representing an optional alias for a Sparkplug B payload.
-[tck-testable tck-id-payloads-alias-uniqueness]#[yellow-background]*If supplied in an NBIRTH or
+Aliases are optional and not required. *If aliases are used, the following rules apply.*
+*** [tck-testable tck-id-payloads-alias-uniqueness]#[yellow-background]*If supplied in an NBIRTH or
 DBIRTH it MUST be a unique number across this Edge Node's entire set of metrics.*#
-In other words, no two metrics for the same Edge Node can have the same alias. Upon being defined in
-the NBIRTH or DBIRTH, subsequent messages can supply only the alias instead of the metric friendly
-name to reduce overall message size.
+**** Non-normative comment: no two metrics for the same Edge Node can have the same alias. Upon being
+defined in the NBIRTH or DBIRTH, subsequent messages can supply only the alias instead of the metric
+friendly name to reduce overall message size.
+*** [tck-testable tck-id-payloads-alias-birth-requirement]#[yellow-background]*NBIRTH and DBIRTH
+messages MUST include both a metric name and alias.*#
+*** [tck-testable tck-id-payloads-alias-data-cmd-requirement]#[yellow-background]*NDATA, DDATA,
+NCMD, and DCMD messages MUST only include an alias and the metric name MUST be excluded.*#
 * *timestamp*
 ** This is the timestamp in the form of an unsigned 64-bit integer representing the number of
 milliseconds since epoch (Jan 1, 1970).
-[tck-not-testable tck-id-payloads_metric_timestamp_in_UTC]#[yellow-background]*This timestamp MUST
-be in UTC.*# This timestamp is meant to represent the time at which the value of a metric was
+** [tck-testable tck-id-payloads-name-birth-data-requirement]#[yellow-background]*The timestamp MUST
+be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
+** [tck-testable tck-id-payloads-name-cmd-requirement]#[yellow-background]*The timestamp MAY be
+included with metrics in NCMD and DCMD messages.*#
+** [tck-not-testable tck-id-payloads_metric_timestamp_in_UTC]#[yellow-background]*This timestamp
+MUST be in UTC.*#
+*** Non-normative comment: This timestamp represents the time at which the value of a metric was
 captured.
 * *datatype*
 ** [tck-testable tck-id-payloads-metric-datatype-value-type]#[yellow-background]*This MUST be an
 unsigned 32-bit integer representing the datatype.*#
-[tck-testable tck-id-payloads-metric-datatype-value]#[yellow-background]*This value MUST be one of
-the enumerated values as shown in the link:#payloads_b_datatypes[valid Sparkplug Data Types].*#
-[tck-testable tck-id-payloads-metric-datatype-req]#[yellow-background]*This MUST be included in
-Metric Definitions in NBIRTH and DBIRTH messages.*#
+** [tck-testable tck-id-payloads-metric-datatype-value]#[yellow-background]*This value MUST be one
+of the enumerated values as shown in the link:#payloads_b_datatypes[valid Sparkplug Data Types].*#
+** [tck-testable tck-id-payloads-metric-datatype-req]#[yellow-background]*This MUST be included with
+each metric definitions in NBIRTH and DBIRTH messages.*#
 * *is_historical*
 ** This is a Boolean flag which denotes whether this metric represents a historical value. In some
 cases, it may be desirable to send metrics after they were acquired from a device or Edge Node. This


### PR DESCRIPTION
* Stubbed out Sparkplug Aware MQTT Server section
* Cleaned up alias normative statements
* Added some normative statements around timestamps
* Added normative statement with regard to requirements on datatype inclusion with metrics