### PR TITLE
Task/speccleanup

### DIFF
--- a/docs/normative_statements.md
+++ b/docs/normative_statements.md
@@ -8,7 +8,7 @@
 	* STATE/[Primary Host ID]
 
 ## Sparkplug Topic Tokens
-* Primary Host ID: The ASCII identifier for the primary host client.
+* Primary Host ID: The UTF-8 identifier for the primary host client.
 * Namespace Token: The first MQTT topic token MUST always be spAv1.0 or spBv1.0 with the exception of STATE messages. This denotes the payload encoding.
 * Group ID: This MUST be included as the second topic token for every non-STATE topic
 * Edge Node ID: This MUST be included as the fourth topic token for every non-STATE topic
@@ -23,8 +23,8 @@
 
 ## Sparkplug Primary Host Client
 * There MUST not be more than one Sparkplug Primary Host Client connected to any MQTT Server
-* An MQTT 'Will Message' must be registered with the STATE topic. It MUST have a payload with the ASCII string 'OFFLINE', use QoS1, and MUST set the MQTT retain flag to true
-* The STATE message MUST be published after the MQTT CONNACK packet is received with a 'Connection Accepted' response. The payload MUST be an ASCII string with the value of 'ONLINE', it MUST use QoS1, and MUST set the MQTT retain flag to true.
+* An MQTT 'Will Message' must be registered with the STATE topic. It MUST have a payload with the UTF-8 string 'OFFLINE', use QoS1, and MUST set the MQTT retain flag to true
+* The STATE message MUST be published after the MQTT CONNACK packet is received with a 'Connection Accepted' response. The payload MUST be an UTF-8 string with the value of 'ONLINE', it MUST use QoS1, and MUST set the MQTT retain flag to true.
 
 ## Sparkplug Edge Client
 * MUST publish an NBIRTH message after connecting to the MQTT Server and before publishing any other messages
@@ -51,7 +51,7 @@ pending bdSeq number metric that will be published in pending NBIRTH message
 * All non-STATE messages MUST be published with the MQTT 'retain flag' set to false
 
 ## MQTT Will Messages
-* Sparkplug Primary Host Clients MUST register an MQTT Will message with the topic 'STATE/[Primary Host ID]', a payload of an ASCII string 'OFFLINE', MQTT retain=true, and QoS=1
+* Sparkplug Primary Host Clients MUST register an MQTT Will message with the topic 'STATE/[Primary Host ID]', a payload of an UTF-8 string 'OFFLINE', MQTT retain=true, and QoS=1
 * Sparkplug Host Clients that are not the Sparkplug Primary Host Clients MUST NOT register an MQTT Will message
 * Sparkplug Edge Clients MUST register an MQTT Will message with the topic: '[Namespace Token]/[Group ID]/[Sparkplug Verb]/[Edge Node ID]'
 	* MORE TO ADD HERE

--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -29,7 +29,7 @@ to accomplish the three following goals.
 [[introduction_define_an_mqtt_topic_namespace]]
 ==== Define an MQTT Topic Namespace
 
-As noted many times in this document one of the many attractive features of MQTT is that is does not
+As noted many times in this document one of the many attractive features of MQTT is that it does not
 specify any required MQTT Topic Namespace within its implementation. This fact has meant that MQTT
 has taken a dominant position across a wide spectrum of IoT solutions. The intent of the Sparkplug
 Specification is to identify and document a Topic Namespace that is well thought out and optimized
@@ -245,7 +245,7 @@ within the context of that application.
 This represents any device, sensor, or hardware that directly connects to MQTT infrastructure using
 a compliant MQTT v3.1.1 or v5.0 connection with the payload and topic notation as outlined in this
 Sparkplug Specification. With MQTT/Sparkplug enabled directly in the device this could bypass the
-use of a Sparkplug Device in the infrastructure. In this case, the physical device or sensor is
+use of a Sparkplug Edge Node in the infrastructure. In this case, the physical device or sensor is
 the Edge Node. It is up to the developer of the application to decide if the concept of a 'Sparkplug
 Device' is to be used within their application.
 
@@ -273,7 +273,7 @@ MUST publish STATE messages denoting their online and offline status.*#
 [[introduction_primary_host_application]]
 ===== Primary Host Application
 
-A Primary Host Applications may be defined by an Edge Node. The Edge Node's behavior may change
+A Primary Host Application may be defined by an Edge Node. The Edge Node's behavior may change
 based on the status of its configured Primary Host. It is not required that an Edge Node must have
 a Primary Host configured but it may be useful in certain applications. This allows Edge Nodes to
 make decisions based on whether or not the Primary Host Application is online or not. For example,
@@ -293,7 +293,7 @@ infrastructure. There are three primary IDs and one that is a composite ID. Thes
 the following.
 
 * Group ID
-** [tck-testable tck-id-intro-group-id-string]#[yellow-background]*The Group ID MUST be UTF-8 string
+** [tck-testable tck-id-intro-group-id-string]#[yellow-background]*The Group ID MUST be a UTF-8 string
 and used as part of the Sparkplug topics as defined in the link:#topics[Topics Section].*#
 ** [tck-testable tck-id-intro-group-id-chars]#[yellow-background]*Because the Group ID is used in
 MQTT topic strings the Group ID MUST only contain characters allowed for MQTT topics per the MQTT
@@ -301,19 +301,19 @@ Specification.*#
 ** Non-normative comment: The Group ID represents a general grouping of Edge Nodes that makes sense
 within the context of the Sparkplug application and use-case.
 * Edge Node ID
-** [tck-testable tck-id-intro-edge-node-id-string]#[yellow-background]*The Edge Node ID MUST be
+** [tck-testable tck-id-intro-edge-node-id-string]#[yellow-background]*The Edge Node ID MUST be a 
 UTF-8 string and used as part of the Sparkplug topics as defined in the
 link:#topics[Topics Section].*#
 ** [tck-testable tck-id-intro-edge-node-id-chars]#[yellow-background]*Because the Edge Node ID is
-used in MQTT topic strings the Group ID MUST only contain characters allowed for MQTT topics per the
+used in MQTT topic strings the Edge Node ID MUST only contain characters allowed for MQTT topics per the
 MQTT Specification.*#
 ** Non-normative comment: The Edge Node ID represents a unique identifier for an Edge Node within
 the context of the Group ID under which it exists.
 * Device ID
-** [tck-testable tck-id-intro-device-id-string]#[yellow-background]*The Device ID MUST be UTF-8
+** [tck-testable tck-id-intro-device-id-string]#[yellow-background]*The Device ID MUST be a UTF-8
 string and used as part of the Sparkplug topics as defined in the link:#topics[Topics Section].*#
 ** [tck-testable tck-id-intro-device-id-chars]#[yellow-background]*Because the Device ID is used in
-MQTT topic strings the Group ID MUST only contain characters allowed for MQTT topics per the MQTT
+MQTT topic strings the Device ID MUST only contain characters allowed for MQTT topics per the MQTT
 Specification.*#
 ** Non-normative comment: The Device ID represents a unique identifier for a Device within the
 context of the Edge Node ID under which it exists.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -39,7 +39,7 @@ specification MUST use the following topic namespace structure:*#
 The namespace element of the topic namespace is the root element that will define both the
 structure of the remaining namespace elements as well as the encoding used for the associated
 payload data. The Sparkplug specification defines two (2) namespaces. One is for Sparkplug payload
-definition A (now deprecated), and another one of for the Sparkplug payload definition B.
+definition A (now deprecated), and the second is for the Sparkplug payload definition B.
 
 [tck-testable tck-id-topic-structure-namespace-a]#[yellow-background]*For the Sparkplug B version of
 the payload definition, the UTF-8 string constant for the namespace element MUST be:*#
@@ -116,7 +116,7 @@ MUST be unique from other devices being reported on by the same Edge Node.*#
 device_id MAY be duplicated from Edge Node to other Edge Nodes.*#
 The device_id element travels with every message published and should be as short as possible.
 [tck-testable tck-id-topic-structure-namespace-device-id-associated-message-types]#[yellow-background]*The
-device_id MUST be included with message_type elements DBIRTH, DDEATH, DDATA, and DCMD based topics*#
+device_id MUST be included with message_type elements DBIRTH, DDEATH, DDATA, and DCMD based topics.*#
 [tck-testable tck-id-topic-structure-namespace-device-id-non-associated-message-types]#[yellow-background]*The
 device_id MUST NOT be included with message_type elements NBIRTH, NDEATH, NDATA, NCMD, and STATE
 based topics*#
@@ -147,7 +147,7 @@ infrastructure.
 values.
 * Issue write/command messages to any Edge Node or Device metric.
 
-This section defines the payload contents and how each of the associated messages types can be used.
+This section defines the payload contents and how each of the associated message types can be used.
 
 [[topics_edge_node]]
 ==== Edge Node

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -60,7 +60,7 @@ single MQTT Server. The steps outlined in the session diagram are defined as fol
 
 [arabic]
 . Sparkplug Host Applications will try to create an MQTT Session using the MQTT CONNECT Control
-Packet. A Death Certificate is constructed into the MQTT Will Topic and Will Payload of the of the
+Packet. A Death Certificate is constructed into the MQTT Will Topic and Will Payload of the
 CONNECT Control Packet with a Will QoS set to 1 and Will Retain flag set to true.
 [tck-testable tck-id-message-flow-phid-sparkplug-clean-session]#[yellow-background]*The CONNECT
 Control Packet for all Sparkplug Host Applications MUST set the MQTT 'Clean Session' flag to
@@ -291,7 +291,7 @@ choices are left to the Sparkplug Host Application developer.
 * [tck-testable tck-id-operational-behavior-host-reordering-param]#[yellow-background]*Sparkplug
 Host Applications SHOULD provide a configurable 'Reorder Timeout' parameter*#
 * [tck-testable tck-id-operational-behavior-host-reordering-start]#[yellow-background]*If a message
-arrives with a out of order sequence number, the Host Application SHOULD start a timer denoting the
+arrives with an out of order sequence number, the Host Application SHOULD start a timer denoting the
 start of the Reorder Timeout window*#
 * [tck-testable tck-id-operational-behavior-host-reordering-rebirth]#[yellow-background]*If the
 Reorder Timeout elapses and the missing message(s) have not been received, the Sparkplug Host
@@ -371,7 +371,7 @@ this server if its MQTT Session stays intact and it does not receive the Primary
 DEATH Certificate.
 
 . Having a subscription registered to the MQTT Server on the STATE topic will result in any change
-to the current the Primary Host Application STATE being received immediately. In this case, a
+to the current Primary Host Application STATE being received immediately. In this case, a
 network disruption causes the Primary Host Application MQTT Session to server #2 to be terminated.
 This will cause the MQTT Server, on behalf of the now terminated the Primary Host Application MQTT
 Client to publish the Death Certificate to anyone that is currently subscribed to it. Upon receipt
@@ -479,7 +479,7 @@ a Sparkplug Host Application sends its MQTT CONNECT packet, it MUST include a Wi
 MQTT Will Message's topic MUST be of the form 'STATE/host_id' where host_id is the unique identifier
 of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-payload]#[yellow-background]*The
-MQTT Will Message's payload MUST be the ASCII String of 'OFFLINE'.*#
+MQTT Will Message's payload MUST be the UTF-8 String of 'OFFLINE'.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-qos]#[yellow-background]*The
 MQTT Will Message's MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-retained]#[yellow-background]*The
@@ -495,7 +495,7 @@ after successfully connecting to the MQTT Server.*#
 Host Application's Birth topic MUST be of the form 'STATE/host_id' where host_id is the unique identifier
 of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-payload]#[yellow-background]*The
-Host Application's Birth payload MUST be the ASCII String of 'ONLINE'.*#
+Host Application's Birth payload MUST be the UTF-8 String of 'ONLINE'.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-qos]#[yellow-background]*The
 Host Application's Birth MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-retained]#[yellow-background]*The
@@ -512,7 +512,7 @@ following characteristics.
 Sparkplug Host Application's Death topic MUST be of the form 'STATE/host_id' where host_id is the
 unique identifier of the Sparkplug Host Application.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-payload]#[yellow-background]*The
-Sparkplug Host Application's Death payload MUST be the ASCII String of 'OFFLINE'.*#
+Sparkplug Host Application's Death payload MUST be the UTF-8 String of 'OFFLINE'.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-qos]#[yellow-background]*The
 Sparkplug Host Application's Death MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-death-retained]#[yellow-background]*The
@@ -565,7 +565,7 @@ messages MUST include current values for all metrics.*#
 messages MUST only be published when Device level metrics change.*#
 ** In other words, metric values that have not changed within the same Sparkplug Session MUST not be
 resent until a new Sparkplug session is established.
-* NDATA messages SHOULD be aggregated to include multiple metrics.
+* DDATA messages SHOULD be aggregated to include multiple metrics.
 ** This is up to the application developer in terms of how many metrics should be aggregated in a
 single message, but it typically doesn't make sense to publish an MQTT message for every single
 metric change.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -470,18 +470,18 @@ milliseconds since epoch (Jan 1, 1970).
 be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
 ** [tck-testable tck-id-payloads-name-cmd-requirement]#[yellow-background]*The timestamp MAY be
 included with metrics in NCMD and DCMD messages.*#
-** [tck-not-testable tck-id-payloads_metric_timestamp_in_UTC]#[yellow-background]*This timestamp
+** [tck-not-testable tck-id-payloads_metric_timestamp_in_UTC]#[yellow-background]*The timestamp
 MUST be in UTC.*#
 *** Non-normative comment: This timestamp represents the time at which the value of a metric was
 captured.
 * *datatype*
-** [tck-testable tck-id-payloads-metric-datatype-value-type]#[yellow-background]*This MUST be an
+** [tck-testable tck-id-payloads-metric-datatype-value-type]#[yellow-background]*The datatype MUST be an
 unsigned 32-bit integer representing the datatype.*#
-** [tck-testable tck-id-payloads-metric-datatype-value]#[yellow-background]*This value MUST be one
+** [tck-testable tck-id-payloads-metric-datatype-value]#[yellow-background]*The datatype MUST be one
 of the enumerated values as shown in the link:#payloads_b_datatypes[valid Sparkplug Data Types].*#
-** [tck-testable tck-id-payloads-metric-datatype-req]#[yellow-background]*This MUST be included with
-each metric definitions in NBIRTH and DBIRTH messages.*#
-** [tck-testable tck-id-payloads-metric-datatype-not-req]#[yellow-background]*This SHOULD NOT be
+** [tck-testable tck-id-payloads-metric-datatype-req]#[yellow-background]*The datatype MUST be included with
+each metric definition in NBIRTH and DBIRTH messages.*#
+** [tck-testable tck-id-payloads-metric-datatype-not-req]#[yellow-background]*The datatype SHOULD NOT be
 included with metric definitions in NDATA, NCMD, DDATA, and DCMD messages.*#
 * *is_historical*
 ** This is a Boolean flag which denotes whether this metric represents a historical value. In some
@@ -644,7 +644,7 @@ A Sparkplug B PropertySetList object is an array of PropertySet objects. It incl
 components.
 
 * *propertyset*
-** This is an array of link:#payloads_b_propertyset[PropetrySet objects].
+** This is an array of link:#payloads_b_propertyset[PropertySet objects].
 
 [[payloads_b_dataset]]
 ==== DataSet
@@ -717,13 +717,13 @@ referred to as 'User Defined Types' or UDTs. There are two types of Templates.
 * *Template Definition*
 ** This is the definition of a Sparkplug Template.
 [tck-testable tck-id-payloads-template-definition-is-definition]#[yellow-background]*A Template
-Definition MUST have is_definitiion set to true.*#
+Definition MUST have is_definition set to true.*#
 [tck-testable tck-id-payloads-template-definition-ref]#[yellow-background]*A Template Definition
 MUST omit the template_ref field.*#
 * *Template Instance*
 ** This is an instance of a Sparkplug Template.
 [tck-testable tck-id-payloads-template-instance-is-definition]#[yellow-background]*A Template
-Instance MUST have is_definitiion set to false.*#
+Instance MUST have is_definition set to false.*#
 [tck-testable tck-id-payloads-template-instance-ref]#[yellow-background]*A Template Instance MUST
 have template_ref set to the type of template definition it is.*#
 In other words, it must be set to the name of the metric that represents the template definition.
@@ -1133,7 +1133,7 @@ sequence number.*#
 include a sequence number value that is one greater than the previous sequence number sent by the
 Edge Node. This value MUST never exceed 255. If in the previous sequence number sent by the Edge
 Node was 255, the next sequence number sent MUST have a value of 0.*#
-* [tck-testable tck-id-payloads-dbirth-order]#[yellow-background]*All DBIRTH messages sent by and
+* [tck-testable tck-id-payloads-dbirth-order]#[yellow-background]*All DBIRTH messages sent by an
 Edge Node MUST be sent immediately after the NBIRTH and before any NDATA or DDATA messages are
 published by the Edge Node.*#
 * [tck-testable tck-id-payloads-dbirth-qos]#[yellow-background]*DBIRTH messages MUST be published
@@ -1152,7 +1152,7 @@ In the topic above the following information is known based on the Sparkplug top
 * The ‘Group ID’ is: Sparkplug B Devices
 * The ‘Edge Node ID’ is: Raspberry Pi
 * The ‘Device ID’ is: Pibrella
-* This is an DBIRTH message based on the 'DBIRTH' Sparkplug Verb
+* This is a DBIRTH message based on the 'DBIRTH' Sparkplug Verb
 
 Consider the following Sparkplug B payload in the DBIRTH message shown above:
 
@@ -1252,14 +1252,14 @@ an ordered List of metrics, multiple different change events for multiple differ
 be included in a single NDATA message.
 
 * [tck-testable tck-id-payloads-ndata-timestamp]#[yellow-background]*NDATA messages MUST include a
-payload timestmp that denotes the time at which the message was published.*#
+payload timestamp that denotes the time at which the message was published.*#
 * [tck-testable tck-id-payloads-ndata-seq]#[yellow-background]*Every NDATA message MUST include a
 sequence number.*#
 * [tck-testable tck-id-payloads-ndata-seq-inc]#[yellow-background]*Every NDATA message MUST include
 a sequence number value that is one greater than the previous sequence number sent by the Edge Node.
 This value MUST never exceed 255. If in the previous sequence number sent by the Edge Node was 255,
 the next sequence number sent MUST have a value of 0.*#
-* [tck-testable tck-id-payloads-ndata-order]#[yellow-background]*All NDATA messages sent by and Edge
+* [tck-testable tck-id-payloads-ndata-order]#[yellow-background]*All NDATA messages sent by an Edge
 Node MUST NOT be sent until all the NBIRTH and all DBIRTH messages have been published by the Edge
 Node.*#
 * [tck-testable tck-id-payloads-ndata-qos]#[yellow-background]*NDATA messages MUST be published with
@@ -1315,7 +1315,7 @@ sequence number.*#
 a sequence number value that is one greater than the previous sequence number sent by the Edge Node.
 This value MUST never exceed 255. If in the previous sequence number sent by the Edge Node was 255,
 the next sequence number sent MUST have a value of 0.*#
-* [tck-testable tck-id-payloads-ddata-order]#[yellow-background]*All DDATA messages sent by and Edge
+* [tck-testable tck-id-payloads-ddata-order]#[yellow-background]*All DDATA messages sent by an Edge
 Node MUST NOT be sent until all the NBIRTH and all DBIRTH messages have been published by the Edge
 Node.*#
 * [tck-testable tck-id-payloads-ddata-qos]#[yellow-background]*DDATA messages MUST be published with
@@ -1512,9 +1512,9 @@ the Edge Node should publish a DDEATH to denote that device connectivity has bee
 
 * [tck-testable tck-id-payloads-ddeath-timestamp]#[yellow-background]*DDEATH messages MUST include a
 payload timestamp that denotes the time at which the message was published.*#
-* [tck-testable tck-id-payloads-ddeath-seq]#[yellow-background]*Every NDATA message MUST include a
+* [tck-testable tck-id-payloads-ddeath-seq]#[yellow-background]*Every DDEATH message MUST include a
 sequence number.*#
-* [tck-testable tck-id-payloads-ddeath-seq-inc]#[yellow-background]*Every NDATA message MUST include
+* [tck-testable tck-id-payloads-ddeath-seq-inc]#[yellow-background]*Every DDEATH message MUST include
 a sequence number value that is one greater than the previous sequence number sent by the Edge Node.
 This value MUST never exceed 255. If in the previous sequence number sent by the Edge Node was 255,
 the next sequence number sent MUST have a value of 0.*#
@@ -1528,7 +1528,7 @@ spBv1.0/Sparkplug B Devices/DDEATH/Raspberry Pi/Pibrella
 * The ‘Group ID’ is: Sparkplug B Devices
 * The ‘Edge Node ID’ is: Raspberry Pi
 * The ‘Device ID’ is: Pibrella
-* This is an DDEATH message based on the 'DDEATH' Sparkplug Verb
+* This is a DDEATH message based on the 'DDEATH' Sparkplug Verb
 
 Consider the following Sparkplug B payload in the DDEATH message shown above:
 


### PR DESCRIPTION
- typos and misreferences of message types
- switched ASCII to UTF-8 for host id consistency