### PR TITLE
Cleanup left-overs from the conversion, improve editing experience in IDEs like Eclipse and IntelliJ

### DIFF
--- a/specification/build.gradle.kts
+++ b/specification/build.gradle.kts
@@ -54,7 +54,7 @@ val asciidoctorPdf = tasks.register("asciidoctorPdf", AsciidoctorTask::class) {
     baseDirFollowsSourceDir()
     sourceDirProperty.set(file("build/spec"))
     sources {
-        include("*.adoc", "chapters/*.adoc")
+        include("sparkplug_spec.adoc")
     }
     setOutputDir(buildDir.resolve("docs/pdf"))
 
@@ -105,7 +105,7 @@ val asciidoctorHtml = tasks.register("asciidoctorHtml", AsciidoctorTask::class) 
     baseDirFollowsSourceDir()
     sourceDirProperty.set(file("build/spec"))
     sources {
-        include("*.adoc", "chapters/*.adoc")
+        include("sparkplug_spec.adoc")
     }
     setOutputDir(buildDir.resolve("docs/html"))
 
@@ -144,7 +144,7 @@ val asciidoctorDocbook = tasks.register("asciidoctorDocbook", AsciidoctorTask::c
     baseDirFollowsSourceDir()
     sourceDirProperty.set(file("build/spec"))
     sources {
-        include("*.adoc", "chapters/*.adoc")
+        include("sparkplug_spec.adoc")
     }
     setOutputDir(buildDir.resolve("docs/docbook"))
     outputs.file(buildDir.resolve("docs/docbook/sparkplug_spec.xml"))

--- a/specification/src/main/asciidoc/.asciidoctorconfig
+++ b/specification/src/main/asciidoc/.asciidoctorconfig
@@ -1,0 +1,8 @@
+// provide hints were to find images when rendering in an IDE
+// see: https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html
+:imagesdir: assets/images
+:assetsdir: {asciidoctorconfigdir}/
+:figure-caption!:
+:icons: font
+:listing-caption: Listing
+:compat-mode:

--- a/specification/src/main/asciidoc/chapters/.asciidoctorconfig
+++ b/specification/src/main/asciidoc/chapters/.asciidoctorconfig
@@ -1,0 +1,3 @@
+// provide hints were to find images when rendering in an IDE
+// see: https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html
+:imagesdir: ../assets/images

--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -188,7 +188,7 @@ This specification is split into the following chapters and appendices:
 * link:#acknowledgements[Chapter 9 - Acknowledgements]
 * link:#conformance[Chapter 10 - Conformance]
 * link:#appendix_a[Appendix A - Open Source Software]
-* link:#appendix_c[Appendix B - List of Normative Statements]
+* link:#appendix_b[Appendix B - List of Normative Statements]
 
 [[introduction_terminology]]
 === Terminology
@@ -198,8 +198,8 @@ This specification is split into the following chapters and appendices:
 
 This section details the infrastructure components implemented.
 
+.Figure 1 - MQTT SCADA Infrastructure
 image:extracted-media/media/image5.png[image,width=660,height=314]
-Figure 1 - MQTT SCADA Infrastructure
 
 [[introduction_mqtt_servers]]
 ===== MQTT Server(s)

--- a/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
@@ -27,8 +27,8 @@ publishing any message containing data that it has. This is one of the principal
 that is the decoupling of intelligent devices from any direct connection to any one consumer
 application.
 
+.Figure 2 - Simple MQTT Infrastructure
 image:extracted-media/media/image6.png[image,width=311,height=116]
-Figure 2 - Simple MQTT Infrastructure
 
 [[principles_report_by_exception]]
 === Report by Exception

--- a/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
@@ -15,9 +15,9 @@ Sparkplug®, Sparkplug Compatible, and the Sparkplug Logo are trademarks of the 
 
 This section details the infrastructure components implemented.
 
+.Figure 1 - MQTT SCADA Infrastructure
 image:extracted-media/media/image5.png[image,width=660,height=314]
 
-Figure 1 - MQTT SCADA Infrastructure
 
 [[components_mqtt_servers]]
 === MQTT Server(s)

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -10,6 +10,9 @@ SPDX-License-Identifier: EPL-2.0
 Sparkplug®, Sparkplug Compatible, and the Sparkplug Logo are trademarks of the Eclipse Foundation.
 ////
 
+// set default value if assetsdir hasn't been defined
+ifndef::assetsdir[:assetsdir:]
+
 [[operational_behavior]]
 == Operational Behavior
 
@@ -79,10 +82,9 @@ Certificates. Any Edge Node that has specified this Sparkplug Host Application a
 Application will will wait to publish their Birth Certificates until after they receive the STATE
 message denoting that the Primary Host application is online.
 
-// suppress inspection "AsciiDocLinkResolve"
-plantuml::assets/plantuml/host-session-establishment.puml[format=png, alt="Host Session Establishment"]
+.Figure 3 - Host Session Establishment
+plantuml::{assetsdir}assets/plantuml/host-session-establishment.puml[format=svg, alt="Host Session Establishment"]
 //image:extracted-media/media/image7.png[image,width=660,height=492]
-Figure 3 - Host Session Establishment
 
 The session diagram in Figure 3 - Host Session Establishment shows a very simple topology with a
 single MQTT Server. The steps outlined in the session diagram are defined as follows:
@@ -213,11 +215,9 @@ Session' flag. All types of MQTT clients (both Host and Edge Nodes) in a Sparkpl
 always set the 'Clean Session' flag in the MQTT CONNECT packet to true.
 
 
-// suppress inspection "AsciiDocLinkResolve"
-plantuml::assets/plantuml/edge-node-mqtt-session-establishment.puml[format=png, alt="Edge Node MQTT Session Establishment"]
+.Figure 4 - Edge Node MQTT Session Establishment
+plantuml::{assetsdir}assets/plantuml/edge-node-mqtt-session-establishment.puml[format=svg, alt="Edge Node MQTT Session Establishment"]
 //image:extracted-media/media/image8.png[image,width=660,height=508]
-
-Figure 4 - Edge Node MQTT Session Establishment
 
 The session diagram in Figure 4 - Edge Node MQTT Session Establishment shows a very simple topology
 with a single MQTT Server. The steps outlined in the session diagram are defined as follows:
@@ -368,10 +368,9 @@ Device.*#
 In order to expose and populate the metrics from any intelligent device, the following simple
 session diagram outlines the requirements:
 
-// suppress inspection "AsciiDocLinkResolve"
-plantuml::assets/plantuml/mqtt-device-session-establishment.puml[format=png, alt="MQTT Device Session Establishment"]
+.Figure 5 - MQTT Device Session Establishment
+plantuml::{assetsdir}assets/plantuml/mqtt-device-session-establishment.puml[format=svg, alt="MQTT Device Session Establishment"]
 //image:extracted-media/media/image9.png[image,width=660,height=309]
-Figure 5 - MQTT Device Session Establishment
 
 The session diagram in Figure 5 - MQTT Device Session Establishment shows a simple topology with
 all the Sparkplug elements in place i.e. Host Application, MQTT Server(s), Sparkplug Edge Node and
@@ -554,9 +553,9 @@ because of network issues. The following message flow diagram outlines how the S
 used when three (3) MQTT Servers are available in the infrastructure:
 
 // suppress inspection "AsciiDocLinkResolve"
-plantuml::assets/plantuml/primary-host-application-state-flow-diagram.puml[format=png, alt="Primary Host Application STATE flow diagram"]
+.Figure 7 – Primary Host Application STATE flow diagram
+plantuml::{assetsdir}assets/plantuml/primary-host-application-state-flow-diagram.puml[format=svg, alt="Primary Host Application STATE flow diagram"]
 //image:extracted-media/media/image11.png[image,width=660,height=304]
-Figure 7 – Primary Host Application STATE flow diagram
 
 [arabic]
 . When an Edge Node is configured with multiple available MQTT Servers in the infrastructure it
@@ -643,10 +642,9 @@ The following simple message flow diagram demonstrates the messages used to upda
 cellular RSSI value in the Primary Host Application and sending a command from the Primary Host
 Application to the Edge Node to use a different primary network path.
 
-// suppress inspection "AsciiDocLinkResolve"
-plantuml::assets/plantuml/edge-node-ndata-and-ncmd-message-flow.puml[format=png, alt="Edge Node NDATA and NCMD Message Flow"]
+.Figure 6 - Edge Node NDATA and NCMD Message Flow
+plantuml::{assetsdir}assets/plantuml/edge-node-ndata-and-ncmd-message-flow.puml[format=svg, alt="Edge Node NDATA and NCMD Message Flow"]
 //image:extracted-media/media/image10.png[image,width=660,height=303]
-Figure 6 - Edge Node NDATA and NCMD Message Flow
 
 [arabic]
 . Assuming MQTT Server is available.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -380,9 +380,8 @@ Using this convention in conjunction with the *group_id*, *edge_node_id* and *de
 defined in the Topic Namespace, consuming applications can organize metrics in the same hierarchical
 fashion:
 
+.Figure 8 – Payload Metric Folder Structure
 image:extracted-media/media/image12.png[image,width=638,height=139]
-
-Figure 8 – Payload Metric Folder Structure
 
 [[payloads_b_sparkplug_bv1_0_payload_components]]
 ==== Sparkplug B v1.0 Payload Components
@@ -1149,9 +1148,8 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 
 This would result in a structure as follows on the Host Application.
 
+.Figure 9 – Sparkplug B Metric Structure 1
 image:extracted-media/media/image13.png[image,width=752,height=332]
-
-Figure 9 – Sparkplug B Metric Structure 1
 
 [[payloads_b_dbirth]]
 ==== DBIRTH
@@ -1270,9 +1268,8 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
 
 This would result in a structure as follows on the Host Application.
 
+.Figure 10 – Sparkplug B Metric Structure 2
 image:extracted-media/media/image14.png[image,width=721,height=341]
-
-Figure 10 – Sparkplug B Metric Structure 2
 
 [[payloads_b_ndata]]
 ==== NDATA

--- a/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
@@ -65,9 +65,8 @@ Sparkplug Host Applications, and MQTT enabled Devices. Each component can connec
 MQTT Server. A message sent to any MQTT Server will be distributed to all available MQTT Servers in
 the cluster (which will distribute the message to all subscribing Sparkplug components).
 
+.Figure X – High Availability MQTT Server Cluster
 image:extracted-media/media/image15.png[image,width=660,height=314]
-
-Figure X – High Availability MQTT Server Cluster
 
 If any MQTT Server would fail, the MQTT connection for components connected to the broker will break
 and the component can connect to any other MQTT Server to resume operations.
@@ -81,9 +80,8 @@ beforehand (like in cloud native deployment environments such as Kubernetes) or 
 not desired that all IP addresses (or DNS lookup names) are configured on the Sparkplug components,
 a load balancer might be used.
 
+.Figure X – High Availability MQTT Server Cluster with Load Balancer
 image:extracted-media/media/image16.png[image,width=660,height=314]
-
-Figure X – High Availability MQTT Server Cluster with Load Balancer
 
 A load balancer acts as the single point of contact for Sparkplug components, so only a single IP
 address or DNS name needs to be configured on the components. The load balancer will proxy the MQTT
@@ -128,9 +126,8 @@ Primary Host Application does not result in Edge Nodes being “stranded” on a
 network issues. The following message flow diagram outlines how the STATE message is used when three
 (3) MQTT Servers are available in the infrastructure:
 
+.Figure 7 – Primary Application STATE flow diagram
 image:extracted-media/media/image11.png[image,width=660,height=304]
-
-Figure 7 – Primary Application STATE flow diagram
 
 [arabic]
 . When an Edge Node is configured with multiple available MQTT Servers in the infrastructure it

--- a/specification/src/main/asciidoc/sparkplug_spec.adoc
+++ b/specification/src/main/asciidoc/sparkplug_spec.adoc
@@ -11,6 +11,27 @@ SPDX-License-Identifier: EPL-2.0
 = Sparkplug 3.0.0-SNAPSHOT: Sparkplug Specification
 Eclipse Sparkplug Contributors
 Version 3.0.0-SNAPSHOT Snapshot Release, {docdate}
+// Settings:
+//:experimental:
+:reproducible:
+:icons: font
+:listing-caption: Listing
+:sectnums:
+:toc:
+:toclevels: 3
+:docinfo: shared,private
+:autofit-option:
+// after importing all the figures had a specific number, therfore, disable automatic numbering by unsetting the figure caption
+:figure-caption!:
+:assetsdir:
+ifdef::backend-pdf[]
+:sectanchors:
+:doctype: book
+:compat-mode:
+:pdf-page-size: Letter
+:source-highlighter: rouge
+:rouge-style: googlecode
+endif::[]
 
 image::extracted-media/media/image3.png[image,width=195,height=90]
 image::extracted-media/media/image4.png[image,width=200,height=80]
@@ -22,28 +43,7 @@ image::extracted-media/media/image4.png[image,width=200,height=80]
 |2.1 |12/10/16 |Cirrus Link |Payload B Addition
 |2.2 |10/11/19 |Cirrus Link |Re-branding for Eclipse foundation added TM to Sparkplug
 |3.0 |11/1/20 |Eclipse Sparkplug Specification Project Team |Reorganized to be in adoc format and to include normative and non-normative statements
-| | | |
-| | | |
 |===
-
-// Settings:
-//:experimental:
-:reproducible:
-:icons: font
-:listing-caption: Listing
-:sectnums:
-:toc:
-:toclevels: 3
-:docinfo: shared,private
-:autofit-option:
-ifdef::backend-pdf[]
-:sectanchors:
-:doctype: book
-:compat-mode:
-:pdf-page-size: Letter
-:source-highlighter: rouge
-:rouge-style: googlecode
-endif::[]
 
 include::chapters/Sparkplug_1_Introduction.adoc[]
 include::chapters/Sparkplug_2_Principles.adoc[]


### PR DESCRIPTION
I've been looking at the AsciiDoc setup used in this project to see it could be used for another upcoming specification at the Eclipse foundation. 

This tackles some of the things I found after opening it in my local IDE: 

* The updated build creates only a single output file as this avoids warnings about missing references, and as the title page would depend on attributes present only in the main document.
* Images and diagrams weren't showing in my IDE when I opened the separate chapters. Therefore I added `.asciidoctorconfig` files that have hints for the IDE to render a preview of the single chapters. The path to the PlantUML files is now an attribute so it can be adjusted whether a single chapter is viewed of the whole document. 
* The figure titles present from a previous conversion are now titles to the respective figure. This ensures that they are on the same page when creating for example a PDF. A future revision can reference their titles in the text.
* Some attribute are meant to be document level attributes and should go directly after the title in the main document. That why I reordered them in the main document.
* Render PlantUML diagrams as SVG as vector diagrams look better when creating a PDF output.

Please let me know if this is helpful or if it needs additional mending of things. 