### PR TITLE
Add references to MQTT features 

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -343,6 +343,23 @@ change values at the Edge.
 [[introduction_normative_references]]
 === Normative References
 
+- [BCP14]
+Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
+Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017.
+
+- [MQTTV50]
+MQTT Version 5.0. Edited by Andrew Banks, Ed Briggs, Ken Borgendale, and Rahul Gupta. 07 March 2019. OASIS Standard. https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html. Latest version: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html.
+
+- [MQTTV311]
+MQTT Version 3.1.1 Plus Errata 01. Edited by Andrew Banks and Rahul Gupta. 10 December 2015. OASIS Standard Incorporating Approved Errata 01. http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html. Latest version: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html.
+
+- [ISO/IEC 20922:2016]
+Information technology — Message Queuing Telemetry Transport (MQTT) v3.1.1
+
+
+[[introduction_list_normative_statements]]
+=== Consolidated List of Normative Statements
+
 A list of all normative statements made in the Sparkplug specification document can be found in
 link:#appendix_b[Appendix B].
 
@@ -389,8 +406,7 @@ to secure an MQTT infrastructure using TLS security.
 === Editing Convention
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-"RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC
-2119. RFC 2119: https://tools.ietf.org/html/rfc2119
+"RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [BCP14].
 
 All normative statements in this document are highlighted in [yellow-background]*yellow text as
 shown here*.
@@ -398,7 +414,7 @@ shown here*.
 [[introduction_leveragint_standards_and_open_source]]
 === Leveraging Standards and Open Source
 
-In addition to leveraging MQTT v3.1.1 and MQTT v5.0 standards, the Sparkplug Specification leverages
+In addition to leveraging MQTT v3.1.1 [MQTTV311] and MQTT v5.0 [MQTTV50] standards, the Sparkplug Specification leverages
 as much open source development tooling and data encoding as possible. Many different open source
 organizations, projects, and ideas were used in the development of the Sparkplug Specification. More
 information on these can be found in link:#appendix_a[Appendix A]

--- a/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
@@ -36,7 +36,7 @@ Figure 2 - Simple MQTT Infrastructure
 The Sparkplug Specification uses the concept of Report by Exception (RBE). Because Sparkplug
 utilizes the built in functions of MQTT to maintain session awareness, messages only need to be sent
 by an Edge Node when values at the edge change. In the initial BIRTH messages, all of the current
-metric values are published in the payload. Because the MQTT session is stateful, after the initial
+metric values are published in the payload. Because the MQTT session is stateful [MQTTV5-4.1], after the initial
 BIRTH messages are sent, new metric values only need to be published when the values change.
 
 Sparkplug does not require that RBE be used in all cases. This is to account for special
@@ -70,7 +70,7 @@ real-time SCADA, the “state” of the end device needs to be always known. In 
 host could only rely on RBE data arriving reliably if it could be assured of the state of the MQTT
 session.
 
-The Eclipse Sparkplug specification defines the use of the MQTT “Will Message” feature to provide
+The Eclipse Sparkplug specification defines the use of the MQTT “Will Message” feature [MQTTV5-3.1.2.5] to provide
 MQTT session state information to any other interested MQTT client in the infrastructure. The
 session state awareness is implemented around a set of defined BIRTH and DEATH topic namespace and
 payload definitions in conjunction with the MQTT connection “Keep Alive” timer.
@@ -99,7 +99,7 @@ link:#payloads_b_state[Host Application Birth Certificates]
 === Persistent vs Non-Persistent Connections for Edge Nodes
 
 Persistent connections are intended to remain connected to the MQTT infrastructure at all times.
-They never send an MQTT DISCONNECT control packet during normal operation. This fact lets the
+They never send an MQTT DISCONNECT control packet [MQTTV5-3.14] during normal operation. This fact lets the
 Host Applications provide the real-time state of every persistent node in the infrastructure within
 the configured MQTT Keep Alive period using the BIRTH/DEATH mechanisms defined above.
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
@@ -35,12 +35,12 @@ and scalability within any given infrastructure.
 [[components_mqtt_edge_node]]
 === MQTT Edge Node
 
-In the context of this specification, an MQTT Edge Node is any MQTT v3.1.1 or v5.0 compliant MQTT
-Client application that manages an MQTT session and provides the physical and/or logical gateway
-functions required to participate in the topic namespace and payload definitions described in this
-document. The Edge Node is responsible for any local protocol interface to existing legacy devices
-(PLCs, RTUs, Flow Computers, Sensors, etc.) and/or any local discrete I/O, and/or any logical
-internal process variables(PVs).
+In the context of this specification, an MQTT Edge Node is any MQTT v3.1.1 [MQTTV3.1.1] or v5.0 
+[MQTTV5] compliant MQTT Client application that manages an MQTT session and provides the physical 
+and/or logical gateway functions required to participate in the topic namespace and payload 
+definitions described in this document. The Edge Node is responsible for any local protocol 
+interface to existing legacy devices (PLCs, RTUs, Flow Computers, Sensors, etc.) and/or any local 
+discrete I/O, and/or any logical internal process variables(PVs).
 
 [[components_device_sensor]]
 === Device / Sensor 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -50,12 +50,12 @@ critical to all timestamps in Sparkplug.
 [[operational_behavior_case_sensitivity]]
 === Case Sensitivity in Sparkplug
 
-The MQTT specification states that MQTT topics are case sensitive. For example, the topic a/b is
-different than A/b. Sparkplug in turn is also case sensitive with regard to both topics as well as
-metric names. So, a metric 'temperature' is not the same as the metric 'Temperature'. However, this
-generally should be avoided. Many Host Applications may not be able to differentiate the two metric
-names as unique. Many databases are case-insensitive and would not be able to handle this situation
-well.
+The MQTT specification states that MQTT topics are case sensitive [MQTTV5-4.7.3]. For example, the 
+topic a/b is different than A/b. Sparkplug in turn is also case sensitive with regard to both topics 
+as well as metric names. So, a metric 'temperature' is not the same as the metric 'Temperature'. 
+However, this generally should be avoided. Many Host Applications may not be able to differentiate 
+the two metric names as unique. Many databases are case-insensitive and would not be able to handle 
+this situation well.
 
 * [tck-testable tck-id-case-sensitivity-sparkplug-ids]#[yellow-background]*Edge Nodes in a Sparkplug
 environment SHOULD NOT have Sparkplug IDs (Group, Edge Node, or Device IDs) that when converted to

--- a/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
@@ -42,8 +42,10 @@ MQTT Client credentials and some considerations on setting up proper ACL’s on 
 [[security_implementation_notes_mqtt]]
 ==== Underlying MQTT Security
 All aspects specified in the MQTT Specification's
-link:++http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718111++[Security Section]
-should be considered when implementing a Sparkplug solution.
+link:++http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718111++[Security Section] 
+[MQTTV3.1.1-5] should be considered when implementing a Sparkplug solution. If using MQTT v5, please
+refer to link:++https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901261++[this 
+section] [MQTTV5-5] instead.
 
 [[security_implementation_notes_encryption]]
 ==== Encrypted Sockets


### PR DESCRIPTION
As described in issue #257, I created a proper normative references section and replaced references to RFC 2119 by BCP 14. I also
added a bunch of references to the MQTT specification where applicable.  