### PR TITLE
Adding a GitHub action to build the specification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build
+on:
+  push: {}
+  pull_request: {}
+jobs:
+
+  gradleValidation:
+    name: Gradle Wrapper
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@v3
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+  build:
+    name: Build
+    needs: gradleValidation
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          cache: 'gradle'
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Build Plugin
+        run: ./gradlew build
+
+      - name: Upload specification artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sparkplug_spec
+          path: specification/build/docs/pdf/sparkplug_spec.pdf
+          if-no-files-found: error
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: tck/build/coverage-report/**/*
+          if-no-files-found: error
+

--- a/specification/build.gradle.kts
+++ b/specification/build.gradle.kts
@@ -95,7 +95,9 @@ val asciidoctorPdf = tasks.register("asciidoctorPdf", AsciidoctorTask::class) {
                 "pdf-theme" to "sparkplug"
         ))
     }
-
+    asciidoctorj {
+        failureLevel = org.asciidoctor.gradle.base.log.Severity.WARN
+    }
 }
 
 val asciidoctorHtml = tasks.register("asciidoctorHtml", AsciidoctorTask::class) {
@@ -135,6 +137,9 @@ val asciidoctorHtml = tasks.register("asciidoctorHtml", AsciidoctorTask::class) 
                 "imagesdir" to "assets/images"
         ))
     }
+    asciidoctorj {
+        failureLevel = org.asciidoctor.gradle.base.log.Severity.WARN
+    }
 }
 
 val asciidoctorDocbook = tasks.register("asciidoctorDocbook", AsciidoctorTask::class) {
@@ -172,6 +177,9 @@ val asciidoctorDocbook = tasks.register("asciidoctorDocbook", AsciidoctorTask::c
                 "project-version" to version,
                 "imagesdir" to "assets/images"
         ))
+    }
+    asciidoctorj {
+        failureLevel = org.asciidoctor.gradle.base.log.Severity.WARN
     }
 }
 


### PR DESCRIPTION
When submitting my first PR to this project, I noticed that no GitHub actions and thereby no automatic checks were running. 

This PR adds:
* a Gradle build of everything plus caching of the Gradle dependencies. 
* uploads both the coverage report and the PDF spec as artifacts so they can be downloaded via the browser by those with permissions.
* it tightens the failure level of the Asciidoctor steps so every warning or error message would break the build.

For this to work, GitHub actions would need to be activated for the repository.

Please feel free to merge it as is, or see it as a start of a discussion what else should be added. 

I've seen projects like the Keycloak project to add a "nightly build" to their GitHub releases (see: https://github.com/keycloak/keycloak/releases). This allows visitors to download the latest and greatest from a central location, while the artifacts attached to a GitHub action are not accessible to the public. 

If you think this would be a good fit for the Sparkplug project as well, please let me know. It could be part of another pull request after this one has been merged. Again, this would be implemented using a GitHub action. 
