### PR TITLE
Converted images as specified in issue #295.

### DIFF
--- a/specification/src/main/asciidoc/assets/plantuml/HA-mqtt-server-cluster-with-load-balancer.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/HA-mqtt-server-cluster-with-load-balancer.puml
@@ -1,0 +1,99 @@
+@startuml
+/'
+ ' Unfortunately, the AsciiDoctor PlantUML plugin dfoes not invoke the PlantUMP pre-processor.
+ ' The consequence is that we have lots of redundant markup instead of clean procedures below.
+ '/
+hide stereotype
+skinparam linetype polyline
+skinparam nodesep 70
+skinparam ranksep 50
+skinparam defaultTextAlignment center
+skinparam monochrome true
+
+skinparam rectangle {
+	BackgroundColor #white
+}
+
+skinparam rectangle<<mqttserver>> {
+	BackgroundColor #lightgrey
+}
+
+skinparam rectangle<<loadbalancer>> {
+	BackgroundColor #darkgrey
+	Roundcorner 50
+}
+
+
+skinparam rectangle<<textBlock>> {
+	BackgroundColor #white
+	BorderThickness 0
+	BorderColor transparent
+	FontSize 28
+	Shadowing false
+}
+
+
+together {
+	rectangle EdgeNode [
+		"" ""
+		===""MQTT Edge""
+		===""    Node    ""
+    	"" ""
+	]
+	rectangle Device [
+		"" ""
+		===""MQTT Enabled""
+		===""Device""
+    	"" ""
+	]
+	rectangle PrimaryHost [
+		"" ""
+		===""Primary Host""
+		===""Application""
+	   	"" ""
+	]	
+}
+
+'together {
+	'rectangle "Load Balancer" <<textBlock>> as LoadBalancerLabel
+	rectangle LoadBalancer<<loadbalancer>> [
+		===""      ""
+		==="" Load Balancer ""
+		===""      ""
+	]
+'}
+
+together {
+	rectangle "MQTT Server" <<textBlock>> as MQTTServerLabel
+	rectangle MQTTNode1<<mqttserver>> [
+		===""  ""
+	]
+	rectangle MQTTNode2<<mqttserver>> [
+		===""  ""
+	]
+	rectangle MQTTNode3<<mqttserver>> [
+		===""  ""
+	]
+}
+
+'[LoadBalancer] -[hidden]down- [LoadBalancerLabel]
+
+[Device] -[hidden]up- [PrimaryHost]
+[Device] -[hidden]down- [EdgeNode]
+
+[Device] <-left-> [LoadBalancer]
+[EdgeNode] <-up-> [LoadBalancer]
+[PrimaryHost] <-down-> [LoadBalancer]
+
+[MQTTNode3] -[hidden]right- [MQTTServerLabel]
+[MQTTNode1] -down- [MQTTNode2]
+[MQTTNode1] -right- [MQTTNode3]
+[MQTTNode2] -down- [MQTTNode3]
+
+[MQTTNode1] <-left--> [LoadBalancer] 
+[MQTTNode2] <-right-> [LoadBalancer]
+[MQTTNode3] <-right-> [LoadBalancer]
+
+	
+
+@enduml

--- a/specification/src/main/asciidoc/assets/plantuml/HA-mqtt-server-cluster.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/HA-mqtt-server-cluster.puml
@@ -1,0 +1,85 @@
+@startuml
+/'
+ ' The "left to right direction" directive below changes how the engine renders the diagram. 
+ '  
+ ' Since the default layout is "top to bottom", we need to specify directions that take into account
+ ' the global change in orientation. So, below, "right" means "up" and "up" means "left".
+ '
+ ' The order of the associations also influences the rendering order.
+ '
+ ' Unfortunately, the AsciiDoctor PlantUML plugin dfoes not invoke the PlantUMP pre-processor.
+ ' The consequence is that we have lots of redundant markup instead of clean procedures below.
+ '/
+left to right direction 
+hide stereotype
+skinparam linetype polyline
+skinparam nodesep 40
+skinparam ranksep 20
+skinparam defaultTextAlignment center
+skinparam monochrome true
+
+skinparam rectangle {
+	BackgroundColor #white
+}
+
+skinparam rectangle<<mqttserver>> {
+	BackgroundColor #lightgrey
+}
+
+skinparam rectangle<<textBlock>> {
+	BackgroundColor #white
+	BorderThickness 0
+	BorderColor transparent
+	FontSize 28
+	Shadowing false
+}
+
+
+together {
+	rectangle "MQTT Server" <<textBlock>> as MQTTServerLabel
+	rectangle EdgeNodeMQTTNode<<mqttserver>> [
+		===""  ""
+	]
+	rectangle DeviceMQTTNode<<mqttserver>> [
+		===""  ""
+	]
+	rectangle PrimaryHostMQTTNode<<mqttserver>> [
+		===""  ""
+	]
+}
+
+together {
+	rectangle EdgeNode [
+		"" ""
+		===""MQTT Edge""
+		===""    Node    ""
+    	"" ""
+	]
+	rectangle Device [
+		"" ""
+		===""MQTT Enabled""
+		===""Device""
+    	"" ""
+	]
+}
+
+rectangle PrimaryHost [
+	"" ""
+	===""Primary Host""
+	===""Application""
+   	"" ""
+]
+
+[EdgeNodeMQTTNode]--left- [DeviceMQTTNode]
+[DeviceMQTTNode] --down- [PrimaryHostMQTTNode] 
+[EdgeNodeMQTTNode] --down- [PrimaryHostMQTTNode]
+
+
+[PrimaryHostMQTTNode] <--down--> [PrimaryHost]
+
+[DeviceMQTTNode] <--up--> [Device]
+
+[EdgeNodeMQTTNode] <--up--> [EdgeNode]	
+	
+
+@enduml

--- a/specification/src/main/asciidoc/assets/plantuml/payload-metric-folder-structure.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/payload-metric-folder-structure.puml
@@ -1,0 +1,16 @@
+@startsalt
+scale 2
+{
+{T!
++**__Metric__**       | **__Value__**       | **__Data Type__**
++ **group_id**        | ""               "" | ""               "" 
+++ edge_node_id       | ""               "" | ""               ""
++++ device_id         | ""               "" | ""               ""
+++++ Metric Level 1   | ""               "" | ""               ""
++++++ Metric Level 2  | ""               "" | ""               ""
+++++++ Metric Name    | ""               "" | ""               ""
+}
+}
+@endsalt
+
+

--- a/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-1.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-1.puml
@@ -13,7 +13,7 @@ scale 2
 +++ Properties                  | Node Properties | ""                              "" | ""               ""
 ++++ Hardware Make              | ""          ""  | ""                 Raspberry Pi "" | ""        String ""
 ++++ Mardware Model             | ""          ""  | ""                 Pi 3 Model B "" | ""        String ""
-++++ OS Version                 | ""          ""  | ""                     Raspbian "" | ""        String ""
+++++ OS Name                    | ""          ""  | ""                     Raspbian "" | ""        String ""
 ++++ OS Version                 | ""          ""  | "" Jessie with PIXEL/11.01.2017 "" | ""        String ""
 ++++ Supply Voltage             | ""          ""  | ""                         12.1 "" | ""         Float ""
 

--- a/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-1.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-1.puml
@@ -1,0 +1,24 @@
+@startsalt
+scale 2
+{
+{T!
++**__Metric__**                 | ""           "" | **__Value__**                      | **__Data Type__**
++**Sparkplug B Devices**        | /group_id       | ""                              "" | ""               "" 
+++ Raspberry Pi                 | /edge_node_id   | ""                              "" | ""               ""
++++ Node Control                | Node Control    | ""                              "" | ""               ""
+++++ Reboot                     | ""           "" | ""                        FALSE "" | ""       Boolean ""
+++++ Rebirth                    | ""           "" | ""                        FALSE "" | ""       Boolean ""
+++++ Next Server                | ""           "" | ""                        FALSE "" | ""       Boolean ""
+++++ Scan Rate                  | ""           "" | ""                         3000 "" | ""         Int64 ""
++++ Properties                  | Node Properties | ""                              "" | ""               ""
+++++ Hardware Make              | ""          ""  | ""                 Raspberry Pi "" | ""        String ""
+++++ Mardware Model             | ""          ""  | ""                 Pi 3 Model B "" | ""        String ""
+++++ OS Version                 | ""          ""  | ""                     Raspbian "" | ""        String ""
+++++ OS Version                 | ""          ""  | "" Jessie with PIXEL/11.01.2017 "" | ""        String ""
+++++ Supply Voltage             | ""          ""  | ""                         12.1 "" | ""         Float ""
+
+}
+}
+@endsalt
+
+

--- a/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-2.puml
+++ b/specification/src/main/asciidoc/assets/plantuml/sparkplugb-metric-structure-2.puml
@@ -1,0 +1,36 @@
+@startsalt
+scale 2
+{
+{T!
++**__Metric__**                 | ""           "" | **__Value__**      | **__Data Type__**
++**Sparkplug B Devices**        | /group_id       | ""              "" | ""           "" 
+++ Raspberry Pi                 | /edge_node_id   | ""              "" | ""           ""
++++ Pibrella                    | /device_id      | ""              "" | ""           ""
+++++ Inputs                     | ""           "" | ""              "" | ""           ""
++++++ A                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ B                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ C                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ D                         | ""           "" | ""        FALSE "" | ""   Boolean ""
+++++ Outputs                    | ""           "" | ""              "" | ""           ""
++++++ LEDs                      | ""           "" | ""              "" | ""           ""
+++++++ Green                    | ""           "" | ""        FALSE "" | ""   Boolean ""
+++++++ Red                      | ""           "" | ""        FALSE "" | ""   Boolean ""
+++++++ Yellow                   | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ E                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ F                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ G                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ H                         | ""           "" | ""        FALSE "" | ""   Boolean ""
++++++ Buzzer                    | ""           "" | ""        FALSE "" | ""   Boolean ""
+++++ Properties                 | ""           "" | ""              "" | ""           ""
++++++ Hardware Make             | ""           "" | ""     Pibrella "" | ""    String ""
+}
+.
+{+
+   Everything under the Pibrella node is 
+   Device Process Variables and Metric Tags
+}
+
+
+}
+
+@endsalt

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -381,7 +381,7 @@ defined in the Topic Namespace, consuming applications can organize metrics in t
 fashion:
 
 .Figure 9 – Payload Metric Folder Structure
-image:extracted-media/media/image12.png[image,width=638,height=139]
+plantuml::{assetsdir}assets/plantuml/payload-metric-folder-structure.puml[format=svg, alt="Payload Metric Folder Structure"]
 
 [[payloads_b_sparkplug_bv1_0_payload_components]]
 ==== Sparkplug B v1.0 Payload Components
@@ -1149,7 +1149,7 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 This would result in a structure as follows on the Host Application.
 
 .Figure 10 – Sparkplug B Metric Structure 1
-image:extracted-media/media/image13.png[image,width=752,height=332]
+plantuml::{assetsdir}assets/plantuml/sparkplugb-metric-structure-1.puml[format=svg, alt="Sparkplug B Metric Structure 1"]
 
 [[payloads_b_dbirth]]
 ==== DBIRTH
@@ -1269,7 +1269,7 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
 This would result in a structure as follows on the Host Application.
 
 .Figure 11 – Sparkplug B Metric Structure 2
-image:extracted-media/media/image14.png[image,width=721,height=341]
+plantuml::{assetsdir}assets/plantuml/sparkplugb-metric-structure-2.puml[format=svg, alt="Sparkplug B Metric Structure 2"]
 
 [[payloads_b_ndata]]
 ==== NDATA

--- a/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
@@ -66,7 +66,7 @@ MQTT Server. A message sent to any MQTT Server will be distributed to all availa
 the cluster (which will distribute the message to all subscribing Sparkplug components).
 
 .Figure 12 – High Availability MQTT Server Cluster
-image:extracted-media/media/image15.png[image,width=660,height=314]
+plantuml::{assetsdir}assets/plantuml/HA-mqtt-server-cluster.puml[format=svg, alt="High Availability MQTT Server Cluster"]
 
 If any MQTT Server would fail, the MQTT connection for components connected to the broker will break
 and the component can connect to any other MQTT Server to resume operations.
@@ -81,8 +81,8 @@ not desired that all IP addresses (or DNS lookup names) are configured on the Sp
 a load balancer might be used.
 
 .Figure 13 – High Availability MQTT Server Cluster with Load Balancer
-image:extracted-media/media/image16.png[image,width=660,height=314]
-
+plantuml::{assetsdir}assets/plantuml/HA-mqtt-server-cluster-with-load-balancer.puml[format=svg, alt="High Availability MQTT Server Cluster with Load Balancer"]
+//
 A load balancer acts as the single point of contact for Sparkplug components, so only a single IP
 address or DNS name needs to be configured on the components. The load balancer will proxy the MQTT
 connections of the components and route to one available MQTT Server. In case of a MQTT Server


### PR DESCRIPTION
Converted image12, 13 and 14 as specified in issue #295. It is impossible to add free textboxes with arrows like in the originals. I added a column to the table to perform the same role.

Signed-off-by: Frédéric Desbiens <frederic.desbiens@eclipse-foundation.org>