### PR TITLE
Limit result logging, exclude Monitoring tests for broker profile

### DIFF
--- a/tck/build.gradle.kts
+++ b/tck/build.gradle.kts
@@ -382,8 +382,8 @@ val unzipHivemq by tasks.registering(Sync::class) {
 
 tasks.prepareHivemqHome {
     //use your own hivemq professional edition instead of unzip each time
-    hivemqFolder.set("/Users/ahelmbre/WorkingGroups/hivemq-4.8.2" as Any)
-    //hivemqFolder.set(unzipHivemq.map { it.destinationDir.resolve("hivemq-ce-2021.1") } as Any)
+
+    hivemqFolder.set(unzipHivemq.map { it.destinationDir.resolve("hivemq-ce-2021.1") } as Any)
     from(projectDir.resolve("hivemq-configuration/config.xml")) {
         into("conf")
     }

--- a/tck/build.gradle.kts
+++ b/tck/build.gradle.kts
@@ -382,8 +382,8 @@ val unzipHivemq by tasks.registering(Sync::class) {
 
 tasks.prepareHivemqHome {
     //use your own hivemq professional edition instead of unzip each time
-    //hivemqFolder.set("/YOUR/PATH/TO/hivemq-4.x.x" as Any)
-    hivemqFolder.set(unzipHivemq.map { it.destinationDir.resolve("hivemq-ce-2021.1") } as Any)
+    hivemqFolder.set("/Users/ahelmbre/WorkingGroups/hivemq-4.8.2" as Any)
+    //hivemqFolder.set(unzipHivemq.map { it.destinationDir.resolve("hivemq-ce-2021.1") } as Any)
     from(projectDir.resolve("hivemq-configuration/config.xml")) {
         into("conf")
     }

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/MQTTListener.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/MQTTListener.java
@@ -86,18 +86,18 @@ public class MQTTListener implements MqttCallbackExtended {
 		}
 	}
 
-	public HashMap<String, String> getResults() {
-		HashMap labelledResults = new HashMap<String, String>();
-        for (int i = 0; i < testIds.length; ++i) {
-            if (testResults.containsKey(testIds[i])) {
-                labelledResults.put("MQTTListener:" + testIds[i], testResults.get(testIds[i]));
-            }
-        }
+	public Map<String, String> getResults() {
+		Map labelledResults = new TreeMap<String, String>();
+		for (int i = 0; i < testIds.length; ++i) {
+			if (testResults.containsKey(testIds[i])) {
+				labelledResults.put("MQTTListener:" + testIds[i], testResults.get(testIds[i]));
+			}
+		}
 		return labelledResults;
 	}
 
 	public void run(String[] args) {
-        if (client != null) {
+		if (client != null) {
             return;
         }
         logger.info("Initialize {} ", clientId);
@@ -153,9 +153,9 @@ public class MQTTListener implements MqttCallbackExtended {
 			if (topic.startsWith(TOPIC_ROOT_STATE+"/")) {
 				System.out.println("Sparkplug message: " + topic + " " + new String(message.getPayload()));
 			} else if (topic.equals(TCK_LOG_TOPIC)) {
-				//System.out.println("TCK log: " + new String(message.getPayload()));
+				System.out.println("TCK log: " + new String(message.getPayload()));
 			} else if (topic.equals(TCK_RESULTS_TOPIC)) {
-				//System.out.println("TCK results: " + new String(message.getPayload()));
+				System.out.println("TCK results: " + new String(message.getPayload()));
 			} else {
 				if (topic.startsWith("spAv1.0/")) {
 					log("Warning - non-standard Sparkplug A message received");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCK.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCK.java
@@ -49,7 +49,7 @@ public class TCK {
 	private final Monitor monitor = new Monitor();
 	private final MQTTListener listener = new MQTTListener();
 	private final Results results = new Results();
-	private @NotNull Boolean hasMonitor;
+	private @NotNull Boolean hasMonitor = true;
 
 	public void MQTTLog(String message) {
 		final PublishService publishService = Services.publishService();

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCK.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCK.java
@@ -49,6 +49,7 @@ public class TCK {
 	private final Monitor monitor = new Monitor();
 	private final MQTTListener listener = new MQTTListener();
 	private final Results results = new Results();
+	private @NotNull Boolean hasMonitor;
 
 	public void MQTTLog(String message) {
 		final PublishService publishService = Services.publishService();
@@ -72,8 +73,9 @@ public class TCK {
 			current = (TCKTest) constructor.newInstance(parameters);
 			current.setProfile(Utils.Profile.valueOf(profile.toUpperCase(Locale.ROOT)));
 			results.initialize(new String[0]);
+			hasMonitor = !current.getProfile().equals(Utils.Profile.BROKER);
 
-			if (!current.getProfile().equals(Utils.Profile.BROKER)) {
+			if (hasMonitor) {
 				monitor.startTest();
 				if (!listenerRunning) {
 					listener.run(new String[0]);
@@ -96,7 +98,7 @@ public class TCK {
 		if (current != null) {
 			logger.info("Test end requested for " + current.getName());
 			final TreeMap<String, String> testResults = new TreeMap<>();
-			if (current.getProfile().equals(Utils.Profile.BROKER)) {
+			if (!hasMonitor) {
 				current.endTest(testResults);
 			} else {
 				testResults.putAll(monitor.getResults());
@@ -105,7 +107,6 @@ public class TCK {
 				monitor.endTest(null);
 				listener.clearResults();
 			}
-
 			current = null;
 		} else {
 			logger.info("Test end requested but no test active");
@@ -113,42 +114,56 @@ public class TCK {
 	}
 
 	public void onMqttConnectionStart(ConnectionStartInput connectionStartInput) {
-		monitor.onMqttConnectionStart(connectionStartInput);
+		if (hasMonitor) {
+			monitor.onMqttConnectionStart(connectionStartInput);
+		}
 	}
 
 	public void onAuthenticationSuccessful(AuthenticationSuccessfulInput authenticationSuccessfulInput) {
-		monitor.onAuthenticationSuccessful(authenticationSuccessfulInput);
+		if (hasMonitor) {
+			monitor.onAuthenticationSuccessful(authenticationSuccessfulInput);
+		}
 	}
 
 	public void onDisconnect(DisconnectEventInput disconnectEventInput) {
-		monitor.onDisconnect(disconnectEventInput);
+		if (hasMonitor) {
+			monitor.onDisconnect(disconnectEventInput);
+		}
 	}
 
 	public void connect(final @NotNull String clientId, final @NotNull ConnectPacket packet) {
 		if (current != null) {
 			current.connect(clientId, packet);
 		}
-		monitor.connect(clientId, packet);
+		if (hasMonitor) {
+			monitor.connect(clientId, packet);
+		}
 	}
 
 	public void disconnect(final @NotNull String clientId, final @NotNull DisconnectPacket packet) {
 		if (current != null) {
 			current.disconnect(clientId, packet);
 		}
-		monitor.disconnect(clientId, packet);
+		if (hasMonitor) {
+			monitor.disconnect(clientId, packet);
+		}
 	}
 
 	public void subscribe(final @NotNull String clientId, final @NotNull SubscribePacket packet) {
 		if (current != null) {
 			current.subscribe(clientId, packet);
 		}
-		monitor.subscribe(clientId, packet);
+		if (hasMonitor) {
+			monitor.subscribe(clientId, packet);
+		}
 	}
 
 	public void publish(final @NotNull String clientId, final @NotNull PublishPacket packet) {
 		if (current != null) {
 			current.publish(clientId, packet);
 		}
-		monitor.publish(clientId, packet);
+		if (hasMonitor) {
+			monitor.publish(clientId, packet);
+		}
 	}
 }

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCKTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/TCKTest.java
@@ -34,7 +34,7 @@ import java.sql.Timestamp;
 import java.util.TreeMap;
 
 import org.eclipse.sparkplug.tck.test.common.Utils;
-import org.eclipse.sparkplug.tck.test.Monitor;
+
 import static org.eclipse.sparkplug.tck.test.common.TopicConstants.*;
 
 /**
@@ -43,20 +43,26 @@ import static org.eclipse.sparkplug.tck.test.common.TopicConstants.*;
  */
 public abstract class TCKTest {
 
-    protected final @NotNull Map<String, String> testResults = new TreeMap<>();
+	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");
+	protected final @NotNull Map<String, String> testResults = new TreeMap<>();
 
-    private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");
+	public Utils.Profile getProfile() {
+		return profile;
+	}
 
-    public void onMqttConnectionStart(ConnectionStartInput connectionStartInput) {
+	public void setProfile(Utils.Profile profile) {
+		this.profile = profile;
+	}
 
-    }
+	protected @NotNull Utils.Profile profile;
 
-    public void onAuthenticationSuccessful(AuthenticationSuccessfulInput authenticationSuccessfulInput) {
+	public void onMqttConnectionStart(ConnectionStartInput connectionStartInput) {
+	}
 
-    }
+	public void onAuthenticationSuccessful(AuthenticationSuccessfulInput authenticationSuccessfulInput) {
+	}
 
 	public void onDisconnect(DisconnectEventInput disconnectEventInput) {
-
 	}
 
 	public abstract void connect(String clientId, ConnectPacket packet);
@@ -73,10 +79,11 @@ public abstract class TCKTest {
 
 	public abstract String[] getTestIds();
 
+
 	public abstract void endTest(Map<String, String> results);
 
 	public void log(String message) {
-		logger.info("TCKTest log " + message);
+		logger.info("TCKTest log: " + message);
 		final PublishService publishService = Services.publishService();
 		final Publish payload = Builders.publish().topic(TCK_LOG_TOPIC).qos(Qos.AT_LEAST_ONCE)
 				.payload(ByteBuffer.wrap(message.getBytes())).build();

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -73,8 +72,8 @@ public class AwareBrokerTest extends TCKTest {
     private BrokerAwareFeatureTester brokerAwareFeatureTester;
 
 	public AwareBrokerTest(TCK aTCK, String[] params) {
-		logger.info("Broker: {} Parameters: {} ", getName(), Arrays.asList(params));
-		theTCK = aTCK;
+        logger.info("Broker: {} Parameters: {} ", getName(), Arrays.asList(params));
+        theTCK = aTCK;
 		testIds.addAll(Arrays.asList(testId));
 		if (params.length < 4) {
 			log("Not enough parameters: " + Arrays.toString(params));
@@ -207,7 +206,7 @@ public class AwareBrokerTest extends TCKTest {
             checkDBIRTHAware(isRetain);
         }
 
-        if (bNBirthChecked && bNDeathChecked) {
+        if (bNBirthChecked && bDBirthChecked) {
             checkStoreAware();
         }
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -66,8 +65,8 @@ public class CompliantBrokerTest extends TCKTest {
     private @NotNull String port;
 
 	public CompliantBrokerTest(TCK aTCK, String[] params) {
-		logger.info("Broker: {} Parameters: {} ", getName(), Arrays.asList(params));
-		theTCK = aTCK;
+        logger.info("Broker: {} Parameters: {} ", getName(), Arrays.asList(params));
+        theTCK = aTCK;
 		testIds.addAll(Arrays.asList(testId));
 		if (params.length < 2) {
 			log("Not enough parameters: " + Arrays.toString(params));

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
@@ -237,6 +237,12 @@ public class Utils {
 		OFFLINE
 	}
 
+	public enum Profile {
+		HOST,
+		EDGE,
+		BROKER
+	}
+
 	public enum TestStatus {
 		NONE,
 		CONSOLE_RESPONSE,

--- a/tck/webconsole/pages/index.vue
+++ b/tck/webconsole/pages/index.vue
@@ -395,14 +395,17 @@ export default {
 
             this.mqttClient.on("message", (topic, message) => {
                 if (topic === resultTopic || topic === logTopic ) {
+                    if (this.logging.length > 100) {
+                        this.logging.shift()
+                    }
                     const logMessage = {
                         logLevel: "INFO",
                         logValue: message.toString(),
                         id: this.logging.length,
                     };
+
                     console.log("logging:", logMessage);
                     this.logging.push(logMessage);
-
                     this.currentTestLogging = logMessage;
                 }
             });


### PR DESCRIPTION
- In situation with heavy load (could be misconfigured) the web console reporting can be flooded with log messages, that could lead into an OOM of the browser. The limit is now shifting older entries away. 
- Specific profiles don't need all internal tests from the internal Monitor, the results from there will be skipped in that case. 