### PR TITLE
Allow host session termination test to work two ways

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
@@ -202,6 +202,27 @@ public class Utils {
 		}
 	}
 
+	public static String getRetained(String topic) {
+		String payload = null;
+		final CompletableFuture<Optional<RetainedPublish>> getFuture =
+				Services.retainedMessageStore().getRetainedMessage(topic);
+		try {
+			Optional<RetainedPublish> retainedPublishOptional = getFuture.get();
+			if (retainedPublishOptional.isPresent()) {
+				final RetainedPublish retainedPublish = retainedPublishOptional.get();
+				ByteBuffer bpayload = retainedPublish.getPayload().orElseGet(null);
+				if (bpayload != null) {
+					payload = StandardCharsets.UTF_8.decode(bpayload).toString();
+				}
+			} else {
+				logger.info("No retained message for topic: " + topic);
+			}
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+		}
+		return payload;
+	}
+
 	public static AtomicBoolean checkHostApplicationIsOnline(String hostApplicationId) {
 		// Check that the host application status is online
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.sparkplug.tck.test.host;
 
-import static org.eclipse.sparkplug.tck.test.common.Constants.TestStatus.DEATH_MESSAGE_RECEIVED;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_CONNECT_BIRTH;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_PAYLOAD;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_QOS;
@@ -44,6 +43,7 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.extension.sdk.api.packets.connect.ConnectPacket;
@@ -58,9 +58,10 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
  * We do know the host application id, but there is no requirement on the MQTT client id, which means the first that we
  * know we are dealing with the host application is the receipt of the STATE message.
  * <p>
- * Currently this test works if the first MQTT client to connect is the host application. To make it completely robust
- * means following all connect/subscribe/publish combinations and ruling out the ones that don't match. There could be
- * many in parallel.
+ * There are two ways of running this test: 1. pass in the host application clientid as a parameter. Start the test with
+ * the host application running, then stop the host application. The clientid parameter must match the MQTT clientid
+ * being used by the host application. 2. start with the host application disconnected. Connect so we can get the MQTT
+ * clientid, then shutdown the host application. The clientid parameter to the test doesn't matter.
  *
  * @author Ian Craggs, Anja Helmbrecht-Schaar
  */
@@ -89,16 +90,19 @@ public class SessionTerminationTest extends TCKTest {
 		logger.info("Primary host {}: Parameters: {} ", getName(), Arrays.asList(params));
 		theTCK = aTCK;
 
-		if (params.length != 2) {
+		if (params.length < 1) {
 			log("Not enough parameters: " + Arrays.toString(params));
-			log("Parameters to host session termination test must be: hostApplicationId hostClientId");
+			log("Parameters to host session termination test must be: hostApplicationId <hostClientId> where the hostClientid is optional");
 			throw new IllegalArgumentException();
 		}
 		hostApplicationId = params[0];
-		hostClientId = params[1];
+		if (params.length == 2) {
+			hostClientId = params[1];
+		}
 
 		logger.info("Parameters are HostApplicationId: {}, HostClientId: {}", hostApplicationId, hostClientId);
 
+		setBdSeq();
 	}
 
 	@Override
@@ -133,6 +137,8 @@ public class SessionTerminationTest extends TCKTest {
 			if (statePayload != null && testStatus == TestStatus.STARTED) {
 				deathBdSeq = statePayload.getBdSeq().shortValue();
 				testStatus = TestStatus.CONNECT_RECEIVED;
+				hostClientId = clientId;
+				logger.info("{} : setting clientid to {}", getName(), hostClientId);
 			} else {
 				logger.error("Test failed on connect.");
 				theTCK.endTest();
@@ -147,11 +153,17 @@ public class SessionTerminationTest extends TCKTest {
 	public void disconnect(final @NotNull String clientId, final @NotNull DisconnectPacket packet) {
 		logger.info("Host - {} test - DISCONNECT - clientId: {}, state: {} ", getName(), clientId, state);
 
+		if (hostClientId == null) {
+			logger.warn("{} host application clientid is not set", getName());
+			return;
+		}
+
 		if (clientId.equals(hostClientId)) {
 			logger.debug("Check Req: {}:{}.", ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL,
 					OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL);
-			testResults.put(ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL, setResult(
-					state == DEATH_MESSAGE_RECEIVED, OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL));
+			testResults.put(ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL,
+					setResult(testStatus == TestStatus.DEATH_RECEIVED,
+							OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL));
 			theTCK.endTest();
 		}
 	}
@@ -165,6 +177,11 @@ public class SessionTerminationTest extends TCKTest {
 	@Override
 	public void publish(final @NotNull String clientId, final @NotNull PublishPacket packet) {
 		logger.info("{} test - PUBLISH - topic: {}, clientId: {} ", getName(), packet.getTopic(), clientId);
+
+		if (hostClientId == null) {
+			logger.warn("{} host application clientid is not set", getName());
+			return;
+		}
 
 		if (clientId.equals(hostClientId) && packet.getTopic().startsWith(Constants.TOPIC_ROOT_STATE)) {
 			if (testStatus == TestStatus.CONNECT_RECEIVED) {
@@ -184,9 +201,9 @@ public class SessionTerminationTest extends TCKTest {
 					logger.error("Received unexpected STATE message from {}", clientId);
 
 				}
-			} else if (testStatus == TestStatus.BIRTH_RECEIVED) {
+			} else if (testStatus == TestStatus.BIRTH_RECEIVED || testStatus == TestStatus.STARTED) {
 				if (checkDeathMessage(packet)) {
-					state = DEATH_MESSAGE_RECEIVED;
+					testStatus = TestStatus.DEATH_RECEIVED;
 				} else {
 					logger.warn("Failed to validate the death message");
 				}
@@ -266,6 +283,22 @@ public class SessionTerminationTest extends TCKTest {
 				setResult(isRetain, OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_RETAINED));
 
 		return overallResult;
+	}
+
+	private void setBdSeq() {
+		String payload = Utils.getRetained(Constants.TOPIC_ROOT_STATE + '/' + hostApplicationId);
+		if (payload != null) {
+			try {
+				ObjectMapper mapper = new ObjectMapper();
+				StatePayload statePayload = mapper.readValue(payload, StatePayload.class);
+				if (statePayload != null && statePayload.isOnline()) {
+					deathBdSeq = statePayload.getBdSeq().shortValue();
+					logger.info("{} setting bdseq to {}", getName(), deathBdSeq);
+				}
+			} catch (Exception e) {
+				logger.error("Failed to handle state topic payload: {}", payload);
+			}
+		}
 	}
 
 	public enum TestStatus {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
@@ -19,12 +19,14 @@ import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_RETAINED;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_TOPIC;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL;
+import static org.eclipse.sparkplug.tck.test.common.Requirements.ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_CONNECT_BIRTH;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_PAYLOAD;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_QOS;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_RETAINED;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_TOPIC;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL;
+import static org.eclipse.sparkplug.tck.test.common.Requirements.OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION;
 import static org.eclipse.sparkplug.tck.test.common.Utils.setResult;
 
 import java.nio.charset.StandardCharsets;
@@ -75,7 +77,8 @@ public class SessionTerminationTest extends TCKTest {
 			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL,
 			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_TOPIC,
 			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_PAYLOAD, ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_QOS,
-			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_RETAINED);
+			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DEATH_RETAINED,
+			ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION);
 
 	private final @NotNull TCK theTCK;
 	private @NotNull String hostApplicationId;
@@ -149,6 +152,9 @@ public class SessionTerminationTest extends TCKTest {
 	@SpecAssertion(
 			section = Sections.OPERATIONAL_BEHAVIOR_SPARKPLUG_HOST_APPLICATION_SESSION_TERMINATION,
 			id = ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL)
+	@SpecAssertion(
+			section = Sections.OPERATIONAL_BEHAVIOR_SPARKPLUG_HOST_APPLICATION_SESSION_TERMINATION,
+			id = ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION)
 	@Override
 	public void disconnect(final @NotNull String clientId, final @NotNull DisconnectPacket packet) {
 		logger.info("Host - {} test - DISCONNECT - clientId: {}, state: {} ", getName(), clientId, state);
@@ -164,6 +170,9 @@ public class SessionTerminationTest extends TCKTest {
 			testResults.put(ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL,
 					setResult(testStatus == TestStatus.DEATH_RECEIVED,
 							OPERATIONAL_BEHAVIOR_HOST_APPLICATION_DISCONNECT_INTENTIONAL));
+
+			testResults.put(ID_OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION, setResult(
+					testStatus == TestStatus.DEATH_RECEIVED, OPERATIONAL_BEHAVIOR_HOST_APPLICATION_TERMINATION));
 			theTCK.endTest();
 		}
 	}

--- a/tck/webconsole/components/Tck/Tests.vue
+++ b/tck/webconsole/components/Tck/Tests.vue
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    Lukas Brand - initial implementation and documentation
+ *    Ian Craggs - updates for usability and features
  ****************************************************************************-->
 
 <template>
@@ -242,20 +243,23 @@ export default {
                         testType: "HOSTAPPLICATION",
                         name: "SessionTerminationTest",
                         readableName: "Session Termination Test",
-                        description: "This is the Host Application Sparkplug session termination test.",
+                        description: `This is the Sparkplug Host Application session termination test. There are 
+                        two ways of running it. Either set the MQTT Client id of an already connected Host Application,
+                        or connect the Host Application while the test is running.`,
                         requirements: [
-                            "Setup a MQTT Connection.",
-                            "Set a Host Application Id that is used by an Application.",
+                            "Connect this console to the HiveMQ broker.",
+                            "Enter the MQTT Client id if the Host Application is already running.",
                             "Start this test.",
-                            "Start the Host Application.",
-                            "Stop the Host Application to trigger events of MQTT messages.",
-                            "Wait until Tests are finished and check Results."
+                            "Start the Host Application, if it wasn't already.",
+                            "Stop the Host Application to trigger the Sparkplug death messages.",
+                            "Wait until the test is finished and check the results.",
+                            "If the test does not stop automatically, press the \"Stop Test\" button."
                         ],
                         parameters: {
                             client_id: {
-                                parameterReadableName: "Host App Id",
+                                parameterReadableName: "MQTT ClientId",
                                 parameterValue: "",
-                                parameterDescription: "The MQTT Client Id of the already connected Host Application",
+                                parameterDescription: "The MQTT Client Id of the Host Application",
                             },
                         },
                         result: null,


### PR DESCRIPTION
Either with the host application already started, in which case you have to enter the MQTT client id. Or with the host application not connected, in which case the test will grab the client id from the connect packet.

I've also updated the console test instructions to match. I think I've made them easier to understand. I'd like to know what you think. If you approve, I'll make similar changes to the other test instructions as I go along.